### PR TITLE
refactor: remove prune_expired configuration and related logic 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@
 2. Evaluation: Calculate validity percentage remaining
 3. Creation: Generate new token if rotation needed
 4. Storage: Write new token + state to Vault
-5. Optional cleanup: Revoke expired tokens if `prune_expired: true`
+
+Note: Expired tokens are automatically pruned by the Linode API - no manual cleanup required
 
 ### Daemon vs One-Shot
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ daemon:
 # Rotation behavior
 rotation:
   threshold_percent: 10 # Rotate when <=10% of validity remains
-  prune_expired: false # Delete expired tokens from Linode API
 
 # Vault configuration
 vault:
@@ -226,12 +225,11 @@ Use a glob pattern to load multiple config files:
    - Current token ID and value
    - Previous token ID and expiry
    - Rotation count and timestamp
-6. **Cleanup** (optional): Prunes expired tokens if `prune_expired: true`
 
 ### Important Behaviors
 
-- **Old tokens are kept**: Previous tokens are NOT deleted until their expiration date
-- **Only manages configured tokens**: Only rotates/deletes tokens in the configuration
+- **Automatic cleanup**: Expired tokens are automatically pruned by the Linode API - no manual cleanup needed
+- **Only manages configured tokens**: Only rotates tokens specified in the configuration
 - **Vault retry on failure**: If Linode succeeds but Vault fails, state is tracked for retry on next run
 - **Graceful shutdown**: Handles SIGTERM/SIGINT for clean daemon shutdown
 
@@ -370,7 +368,6 @@ Structured logging with rotation events, errors, and state changes
 - Enable TLS for Vault communication in production
 - Rotate Vault AppRole secret IDs regularly
 - Review token scopes - use least privilege principle
-- Consider enabling `prune_expired` to reduce token sprawl
 
 ## Roadmap
 

--- a/cmd/latr/main.go
+++ b/cmd/latr/main.go
@@ -65,7 +65,6 @@ func main() {
 		slog.String("mode", cfg.Daemon.Mode),
 		slog.Int("token_count", len(cfg.Tokens)),
 		slog.Int("rotation_threshold_percent", cfg.Rotation.ThresholdPercent),
-		slog.Bool("prune_expired", cfg.Rotation.PruneExpired),
 		slog.Bool("dry_run", cfg.Daemon.DryRun))
 
 	// Set up context with signal handling for graceful shutdown

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,43 +2,42 @@
 
 # Global daemon settings
 daemon:
-  mode: "daemon"                   # "daemon" or "one-shot"
-  check_interval: "30m"            # How often to check tokens (daemon mode only)
-  dry_run: false                   # If true, no actual changes are made
+  mode: "daemon" # "daemon" or "one-shot"
+  check_interval: "30m" # How often to check tokens (daemon mode only)
+  dry_run: false # If true, no actual changes are made
 
 # Rotation behavior
 rotation:
-  threshold_percent: 10            # Rotate when <=10% of validity remains
-  prune_expired: false             # Delete expired tokens from Linode API
+  threshold_percent: 10 # Rotate when <=10% of validity remains
 
 # Vault configuration
 # Environment variables are automatically expanded using ${VAR_NAME} or $VAR_NAME syntax
 vault:
   address: "https://vault.example.com"
-  role_id: "${VAULT_ROLE_ID}"      # Expanded from VAULT_ROLE_ID environment variable
-  secret_id: "${VAULT_SECRET_ID}"  # Expanded from VAULT_SECRET_ID environment variable
-  mount_path: "secret"             # KV v2 mount path
+  role_id: "${VAULT_ROLE_ID}" # Expanded from VAULT_ROLE_ID environment variable
+  secret_id: "${VAULT_SECRET_ID}" # Expanded from VAULT_SECRET_ID environment variable
+  mount_path: "secret" # KV v2 mount path
 
 # Observability settings
 observability:
-  otel_endpoint: "localhost:4317"  # OpenTelemetry collector endpoint (optional)
-  log_level: "info"                # debug, info, warn, error
+  otel_endpoint: "localhost:4317" # OpenTelemetry collector endpoint (optional)
+  log_level: "info" # debug, info, warn, error
 
 # Token definitions
 tokens:
   - label: "my-api-token"
     team: "platform-team"
-    validity: "90d"                # Must be <= 6 months (180d)
-    scopes: "*"                    # "*" for all scopes, or comma-separated list
+    validity: "90d" # Must be <= 6 months (180d)
+    scopes: "*" # "*" for all scopes, or comma-separated list
     storage:
       - type: "vault"
         path: "secret/data/linode/tokens/my-api-token"
 
   - label: "backup-token"
     team: "sre-team"
-    validity: "180d"               # Maximum allowed
+    validity: "180d" # Maximum allowed
     scopes: "linodes:read_only,domains:read_only"
-    rotation_threshold: 15         # Override global threshold for this token
+    rotation_threshold: 15 # Override global threshold for this token
     storage:
       - type: "vault"
         path: "secret/data/linode/tokens/backup"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,8 +28,7 @@ type DaemonConfig struct {
 
 // RotationConfig contains settings for token rotation
 type RotationConfig struct {
-	ThresholdPercent int  `yaml:"threshold_percent"`
-	PruneExpired     bool `yaml:"prune_expired"`
+	ThresholdPercent int `yaml:"threshold_percent"`
 }
 
 // VaultConfig contains Vault connection and authentication settings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,7 +51,6 @@ tokens:
 
 	// Check rotation settings
 	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
-	assert.False(t, cfg.Rotation.PruneExpired)
 
 	// Check vault settings
 	assert.Equal(t, "https://vault.example.com", cfg.Vault.Address)
@@ -104,7 +103,6 @@ tokens:
 	assert.Equal(t, "30m", cfg.Daemon.CheckInterval)
 	assert.False(t, cfg.Daemon.DryRun)
 	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
-	assert.False(t, cfg.Rotation.PruneExpired)
 	assert.Equal(t, "secret", cfg.Vault.MountPath)
 	assert.Equal(t, "info", cfg.Observability.LogLevel)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -71,9 +71,6 @@ func MergeConfigs(base, override *Config) *Config {
 	if override.Rotation.ThresholdPercent != 0 {
 		merged.Rotation.ThresholdPercent = override.Rotation.ThresholdPercent
 	}
-	if override.Rotation.PruneExpired {
-		merged.Rotation.PruneExpired = override.Rotation.PruneExpired
-	}
 
 	// Merge Vault config
 	merged.Vault = base.Vault

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -173,7 +173,6 @@ func TestMergeConfigsOverride(t *testing.T) {
 		},
 		Rotation: RotationConfig{
 			ThresholdPercent: 15,
-			PruneExpired:     true,
 		},
 	}
 
@@ -182,7 +181,6 @@ func TestMergeConfigsOverride(t *testing.T) {
 	// Second config should override first for non-empty values
 	assert.Equal(t, "https://vault2.example.com", merged.Vault.Address)
 	assert.Equal(t, 15, merged.Rotation.ThresholdPercent)
-	assert.True(t, merged.Rotation.PruneExpired)
 }
 
 func TestLoadAndValidate(t *testing.T) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -15,7 +15,6 @@ import (
 // Engine defines the interface for the rotation engine
 type Engine interface {
 	ProcessToken(ctx context.Context, tokenConfig config.TokenConfig, thresholdPercent int) error
-	PruneExpiredTokens(ctx context.Context, managedLabels []string) error
 }
 
 // Scheduler manages the execution schedule for token rotation
@@ -124,19 +123,6 @@ func (s *Scheduler) executeCycle(ctx context.Context) error {
 			}, observability.TraceAttrs(ctx)...)
 			logger.ErrorContext(ctx, "Failed to process token", attrs...)
 			// Continue processing other tokens
-		}
-	}
-
-	// Prune expired tokens if configured
-	if s.config.Rotation.PruneExpired {
-		managedLabels := make([]string, len(s.config.Tokens))
-		for i, token := range s.config.Tokens {
-			managedLabels[i] = token.Label
-		}
-
-		if err := s.engine.PruneExpiredTokens(ctx, managedLabels); err != nil {
-			attrs := append([]any{slog.Any("error", err)}, observability.TraceAttrs(ctx)...)
-			logger.ErrorContext(ctx, "Failed to prune expired tokens", attrs...)
 		}
 	}
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -21,11 +21,6 @@ func (m *MockEngine) ProcessToken(ctx context.Context, tokenConfig config.TokenC
 	return args.Error(0)
 }
 
-func (m *MockEngine) PruneExpiredTokens(ctx context.Context, managedLabels []string) error {
-	args := m.Called(ctx, managedLabels)
-	return args.Error(0)
-}
-
 func TestScheduler_RunOnce(t *testing.T) {
 	mockEngine := new(MockEngine)
 
@@ -35,7 +30,6 @@ func TestScheduler_RunOnce(t *testing.T) {
 		},
 		Rotation: config.RotationConfig{
 			ThresholdPercent: 10,
-			PruneExpired:     false,
 		},
 		Tokens: []config.TokenConfig{
 			{
@@ -68,34 +62,6 @@ func TestScheduler_RunOnce(t *testing.T) {
 	mockEngine.AssertExpectations(t)
 }
 
-func TestScheduler_RunOnce_WithPruning(t *testing.T) {
-	mockEngine := new(MockEngine)
-
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode: "one-shot",
-		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10,
-			PruneExpired:     true,
-		},
-		Tokens: []config.TokenConfig{
-			{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
-		},
-	}
-
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[0], 10).Return(nil)
-	mockEngine.On("PruneExpiredTokens", mock.Anything, []string{"token1"}).Return(nil)
-
-	scheduler := NewScheduler(cfg, mockEngine)
-
-	ctx := context.Background()
-	err := scheduler.Run(ctx)
-	require.NoError(t, err)
-
-	mockEngine.AssertExpectations(t)
-}
-
 func TestScheduler_RunDaemon(t *testing.T) {
 	mockEngine := new(MockEngine)
 
@@ -106,7 +72,6 @@ func TestScheduler_RunDaemon(t *testing.T) {
 		},
 		Rotation: config.RotationConfig{
 			ThresholdPercent: 10,
-			PruneExpired:     false,
 		},
 		Tokens: []config.TokenConfig{
 			{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},

--- a/test/e2e/testdata/config-create.yaml
+++ b/test/e2e/testdata/config-create.yaml
@@ -4,7 +4,6 @@ daemon:
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"

--- a/test/e2e/testdata/config-daemon.yaml
+++ b/test/e2e/testdata/config-daemon.yaml
@@ -5,7 +5,6 @@ daemon:
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"

--- a/test/e2e/testdata/config-dryrun.yaml
+++ b/test/e2e/testdata/config-dryrun.yaml
@@ -4,7 +4,6 @@ daemon:
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"

--- a/test/e2e/testdata/config-rotate.yaml
+++ b/test/e2e/testdata/config-rotate.yaml
@@ -4,7 +4,6 @@ daemon:
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"


### PR DESCRIPTION
Remove prune_expired configuration and related logic from the token rotation process

fixes: #12