### PR TITLE
feat: manage primary token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Go application for automatically managing and rotating Linode API tokens with 
 - **Multiple Tokens**: Manage multiple API tokens with different configurations
 - **Team Metadata**: Associate tokens with owning teams for organization
 - **Flexible Configuration**: Single YAML file or glob pattern support
+- **Self Token Rotation**: Can rotate its own Linode API token in-memory — no restart required
 - **Daemon or One-Shot**: Run as a long-running daemon or one-time execution
 - **Dry-Run Mode**: Test configuration without making changes
 - **OpenTelemetry Support**: Observability via traces, metrics, and logs
@@ -161,6 +162,18 @@ tokens:
     storage:
       - type: "vault"
         path: "secret/data/linode/tokens/backup"
+
+  # Self token rotation: rotates the token used by LINODE_TOKEN itself.
+  # After rotation, latr updates its Linode API client in-memory.
+  # Only one token may have self: true.
+  - label: "latr-main-token"
+    team: "platform-team"
+    validity: "180d"
+    scopes: "*"
+    self: true
+    storage:
+      - type: "vault"
+        path: "secret/data/linode/tokens/latr-main"
 ```
 
 ## Usage
@@ -225,6 +238,14 @@ Use a glob pattern to load multiple config files:
    - Current token ID and value
    - Previous token ID and expiry
    - Rotation count and timestamp
+
+### Self Token Rotation
+
+latr can rotate the very token it uses to authenticate to the Linode API (the
+`LINODE_TOKEN`). Set `self: true` on the token entry that corresponds to
+`LINODE_TOKEN`. After rotating, latr updates its Linode API client in-memory
+with the new token value — no pod restart or external mechanism is needed. Only
+one token may have `self: true`.
 
 ### Important Behaviors
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -49,3 +49,15 @@ tokens:
     storage:
       - type: "vault"
         path: "secret/data/linode/tokens/dev"
+
+  # Self token rotation: this entry manages the token set as LINODE_TOKEN.
+  # After rotation, latr swaps the Linode API client to the new token
+  # in-memory — no restart needed. Only one token may have self: true.
+  - label: "latr-main-token"
+    team: "platform-team"
+    validity: "180d"
+    scopes: "*"
+    self: true
+    storage:
+      - type: "vault"
+        path: "secret/data/linode/tokens/latr-main"

--- a/helm/latr/values.yaml
+++ b/helm/latr/values.yaml
@@ -121,9 +121,15 @@ config:
   #   validity: 90d
   #   scopes: "*"
   #   rotationThreshold: 10
+  #   self: false
   #   storage:
   #     - type: vault
   #       path: secret/data/linode/tokens/my-api-token
+  #
+  # Self token rotation:
+  # Set self: true on the token entry that corresponds to LINODE_TOKEN.
+  # After rotating, latr updates its Linode API client in-memory with the
+  # new token — no pod restart required. Only one token may have self: true.
 
 # Secrets configuration
 # These values should be provided via a separate values file or via --set flags

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ type TokenConfig struct {
 	Validity          string          `yaml:"validity"`
 	Scopes            string          `yaml:"scopes"`
 	RotationThreshold int             `yaml:"rotation_threshold"`
+	Self              bool            `yaml:"self"`
 	Storage           []StorageConfig `yaml:"storage"`
 }
 
@@ -125,10 +126,18 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("at least one token must be configured")
 	}
 
+	selfCount := 0
 	for i, token := range c.Tokens {
 		if err := c.validateToken(&token, i); err != nil {
 			return err
 		}
+		if token.Self {
+			selfCount++
+		}
+	}
+
+	if selfCount > 1 {
+		return fmt.Errorf("only one token may have self: true, found %d", selfCount)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -380,6 +380,105 @@ tokens:
 	assert.Equal(t, "otel-from-env:4317", cfg.Observability.OTelEndpoint)
 }
 
+func TestValidateConfig_MultipleSelfTokens(t *testing.T) {
+	cfg := &Config{
+		Vault: VaultConfig{
+			Address:   "https://vault.example.com",
+			RoleID:    "test-role-id",
+			SecretID:  "test-secret-id",
+			MountPath: "secret",
+		},
+		Tokens: []TokenConfig{
+			{
+				Label:    "self-token-1",
+				Team:     "team",
+				Validity: "90d",
+				Scopes:   "*",
+				Self:     true,
+				Storage:  []StorageConfig{{Type: "vault", Path: "path1"}},
+			},
+			{
+				Label:    "self-token-2",
+				Team:     "team",
+				Validity: "90d",
+				Scopes:   "*",
+				Self:     true,
+				Storage:  []StorageConfig{{Type: "vault", Path: "path2"}},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one token may have self: true")
+}
+
+func TestValidateConfig_SingleSelfToken(t *testing.T) {
+	cfg := &Config{
+		Vault: VaultConfig{
+			Address:   "https://vault.example.com",
+			RoleID:    "test-role-id",
+			SecretID:  "test-secret-id",
+			MountPath: "secret",
+		},
+		Tokens: []TokenConfig{
+			{
+				Label:    "self-token",
+				Team:     "team",
+				Validity: "90d",
+				Scopes:   "*",
+				Self:     true,
+				Storage:  []StorageConfig{{Type: "vault", Path: "path1"}},
+			},
+			{
+				Label:    "other-token",
+				Team:     "team",
+				Validity: "90d",
+				Scopes:   "*",
+				Self:     false,
+				Storage:  []StorageConfig{{Type: "vault", Path: "path2"}},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestParseConfigWithSelfField(t *testing.T) {
+	yamlContent := `
+vault:
+  address: "https://vault.example.com"
+  role_id: "test-role-id"
+  secret_id: "test-secret-id"
+
+tokens:
+  - label: "self-token"
+    team: "platform-team"
+    validity: "90d"
+    scopes: "*"
+    self: true
+    storage:
+      - type: "vault"
+        path: "secret/data/linode/tokens/self"
+  - label: "managed-token"
+    team: "platform-team"
+    validity: "180d"
+    scopes: "linodes:read_write"
+    storage:
+      - type: "vault"
+        path: "secret/data/linode/tokens/managed"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Tokens, 2)
+
+	assert.True(t, cfg.Tokens[0].Self)
+	assert.False(t, cfg.Tokens[1].Self)
+}
+
 func TestParseConfigWithMissingEnvVar(t *testing.T) {
 	yamlContent := `
 vault:

--- a/internal/linode/client.go
+++ b/internal/linode/client.go
@@ -37,6 +37,24 @@ func NewClient(token string) *Client {
 	}
 }
 
+// SetToken updates the client to use a new API token.
+// This recreates the underlying HTTP client with the new token,
+// allowing in-memory token rotation without restarting the process.
+func (c *Client) SetToken(token string) {
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	oauth2Client := oauth2.NewClient(context.Background(), tokenSource)
+
+	newClient := linodego.NewClient(oauth2Client)
+
+	baseURL := os.Getenv("LINODE_API_URL")
+	if baseURL != "" {
+		newClient.SetBaseURL(baseURL)
+	}
+
+	c.client = &newClient
+	c.token = token
+}
+
 // CreateToken creates a new Linode API token
 func (c *Client) CreateToken(ctx context.Context, label, scopes string, expiry time.Time) (*models.Token, error) {
 	createOpts := linodego.TokenCreateOptions{

--- a/internal/rotation/engine.go
+++ b/internal/rotation/engine.go
@@ -17,6 +17,7 @@ import (
 type LinodeClient interface {
 	CreateToken(ctx context.Context, label, scopes string, expiry time.Time) (*models.Token, error)
 	FindTokenByLabel(ctx context.Context, label string) ([]*models.Token, error)
+	SetToken(token string)
 }
 
 // VaultClient defines the interface for Vault operations
@@ -196,6 +197,16 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 		return fmt.Errorf("failed to update token state: %w", err)
 	}
 
+	// If this is the self token, update the Linode client in-memory
+	if tokenConfig.Self {
+		e.linodeClient.SetToken(newToken.Token)
+		attrs := append([]any{
+			slog.String("token_label", tokenConfig.Label),
+			slog.Int("new_token_id", newToken.ID),
+		}, observability.TraceAttrs(ctx)...)
+		logger.InfoContext(ctx, "Updated Linode client with new self token", attrs...)
+	}
+
 	// Record successful rotation
 	span.SetStatus(codes.Ok, "token created successfully")
 	observability.RecordRotation(ctx, tokenConfig.Label, true)
@@ -286,6 +297,17 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 		observability.RecordRotation(ctx, tokenConfig.Label, false)
 		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
 		return fmt.Errorf("failed to update token state: %w", err)
+	}
+
+	// If this is the self token, update the Linode client in-memory
+	if tokenConfig.Self {
+		e.linodeClient.SetToken(newToken.Token)
+		attrs := append([]any{
+			slog.String("token_label", tokenConfig.Label),
+			slog.Int("new_token_id", newToken.ID),
+			slog.Int("previous_token_id", existingToken.ID),
+		}, observability.TraceAttrs(ctx)...)
+		logger.InfoContext(ctx, "Updated Linode client with new self token", attrs...)
 	}
 
 	// Record successful rotation

--- a/internal/rotation/engine_test.go
+++ b/internal/rotation/engine_test.go
@@ -34,6 +34,10 @@ func (m *MockLinodeClient) FindTokenByLabel(ctx context.Context, label string) (
 	return []*models.Token{args.Get(0).(*models.Token)}, args.Error(1)
 }
 
+func (m *MockLinodeClient) SetToken(token string) {
+	m.Called(token)
+}
+
 // MockVaultClient is a mock implementation of the Vault client
 type MockVaultClient struct {
 	mock.Mock
@@ -284,6 +288,176 @@ func TestEngine_ProcessToken_LinodeCreateFails(t *testing.T) {
 	mockLinode.AssertExpectations(t)
 	// Vault write should not be called if Linode creation fails
 	mockVault.AssertNotCalled(t, "WriteToken")
+}
+
+func TestEngine_ProcessToken_SelfToken_NewToken(t *testing.T) {
+	mockLinode := new(MockLinodeClient)
+	mockVault := new(MockVaultClient)
+
+	tokenConfig := config.TokenConfig{
+		Label:    "self-token",
+		Team:     "platform",
+		Validity: "90d",
+		Scopes:   "*",
+		Self:     true,
+		Storage: []config.StorageConfig{
+			{Type: "vault", Path: "secret/data/test/self-token"},
+		},
+	}
+
+	now := time.Now()
+	createdToken := &models.Token{
+		ID:        123,
+		Label:     "self-token",
+		Token:     "new-self-token-value",
+		CreatedAt: now,
+		ExpiresAt: now.Add(90 * 24 * time.Hour),
+		Scopes:    "*",
+		Validity:  90 * 24 * time.Hour,
+	}
+
+	// Token doesn't exist yet
+	mockLinode.On("FindTokenByLabel", mock.Anything, "self-token").Return(nil, nil)
+	mockLinode.On("CreateToken", mock.Anything, "self-token", "*", mock.Anything).Return(createdToken, nil)
+	mockLinode.On("SetToken", "new-self-token-value").Return()
+
+	// Vault operations
+	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/self-token").Return(nil, nil)
+	mockVault.On("WriteToken", mock.Anything, "secret/data/test/self-token", "new-self-token-value").Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/self-token", mock.Anything).Return(nil)
+
+	engine := &Engine{
+		linodeClient: mockLinode,
+		vaultClient:  mockVault,
+		dryRun:       false,
+	}
+
+	ctx := context.Background()
+	err := engine.ProcessToken(ctx, tokenConfig, 10)
+	require.NoError(t, err)
+
+	mockLinode.AssertExpectations(t)
+	mockVault.AssertExpectations(t)
+	// Verify SetToken was called with the new token value
+	mockLinode.AssertCalled(t, "SetToken", "new-self-token-value")
+}
+
+func TestEngine_ProcessToken_SelfToken_Rotation(t *testing.T) {
+	mockLinode := new(MockLinodeClient)
+	mockVault := new(MockVaultClient)
+
+	tokenConfig := config.TokenConfig{
+		Label:    "self-token",
+		Team:     "platform",
+		Validity: "90d",
+		Scopes:   "*",
+		Self:     true,
+		Storage: []config.StorageConfig{
+			{Type: "vault", Path: "secret/data/test/self-token"},
+		},
+	}
+
+	now := time.Now()
+	existingToken := &models.Token{
+		ID:        123,
+		Label:     "self-token",
+		Token:     "",
+		CreatedAt: now.Add(-81 * 24 * time.Hour), // Created 81 days ago
+		ExpiresAt: now.Add(9 * 24 * time.Hour),   // Expires in 9 days (10% remaining)
+		Scopes:    "*",
+		Validity:  90 * 24 * time.Hour,
+	}
+
+	newToken := &models.Token{
+		ID:        456,
+		Label:     "self-token",
+		Token:     "rotated-self-token-value",
+		CreatedAt: now,
+		ExpiresAt: now.Add(90 * 24 * time.Hour),
+		Scopes:    "*",
+		Validity:  90 * 24 * time.Hour,
+	}
+
+	existingState := &models.TokenState{
+		Label:           "self-token",
+		CurrentLinodeID: 123,
+		RotationCount:   2,
+	}
+
+	mockLinode.On("FindTokenByLabel", mock.Anything, "self-token").Return(existingToken, nil)
+	mockLinode.On("CreateToken", mock.Anything, "self-token", "*", mock.Anything).Return(newToken, nil)
+	mockLinode.On("SetToken", "rotated-self-token-value").Return()
+
+	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/self-token").Return(existingState, nil)
+	mockVault.On("WriteToken", mock.Anything, "secret/data/test/self-token", "rotated-self-token-value").Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/self-token", mock.MatchedBy(func(state *models.TokenState) bool {
+		return state.CurrentLinodeID == 456 &&
+			state.PreviousLinodeID == 123 &&
+			state.RotationCount == 3
+	})).Return(nil)
+
+	engine := &Engine{
+		linodeClient: mockLinode,
+		vaultClient:  mockVault,
+		dryRun:       false,
+	}
+
+	ctx := context.Background()
+	err := engine.ProcessToken(ctx, tokenConfig, 10)
+	require.NoError(t, err)
+
+	mockLinode.AssertExpectations(t)
+	mockVault.AssertExpectations(t)
+	mockLinode.AssertCalled(t, "SetToken", "rotated-self-token-value")
+}
+
+func TestEngine_ProcessToken_NonSelfToken_NoSetToken(t *testing.T) {
+	mockLinode := new(MockLinodeClient)
+	mockVault := new(MockVaultClient)
+
+	tokenConfig := config.TokenConfig{
+		Label:    "regular-token",
+		Team:     "platform",
+		Validity: "90d",
+		Scopes:   "*",
+		Self:     false,
+		Storage: []config.StorageConfig{
+			{Type: "vault", Path: "secret/data/test/regular-token"},
+		},
+	}
+
+	now := time.Now()
+	createdToken := &models.Token{
+		ID:        123,
+		Label:     "regular-token",
+		Token:     "new-regular-token",
+		CreatedAt: now,
+		ExpiresAt: now.Add(90 * 24 * time.Hour),
+		Scopes:    "*",
+		Validity:  90 * 24 * time.Hour,
+	}
+
+	mockLinode.On("FindTokenByLabel", mock.Anything, "regular-token").Return(nil, nil)
+	mockLinode.On("CreateToken", mock.Anything, "regular-token", "*", mock.Anything).Return(createdToken, nil)
+
+	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/regular-token").Return(nil, nil)
+	mockVault.On("WriteToken", mock.Anything, "secret/data/test/regular-token", "new-regular-token").Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/regular-token", mock.Anything).Return(nil)
+
+	engine := &Engine{
+		linodeClient: mockLinode,
+		vaultClient:  mockVault,
+		dryRun:       false,
+	}
+
+	ctx := context.Background()
+	err := engine.ProcessToken(ctx, tokenConfig, 10)
+	require.NoError(t, err)
+
+	mockLinode.AssertExpectations(t)
+	mockVault.AssertExpectations(t)
+	// SetToken should NOT be called for non-self tokens
+	mockLinode.AssertNotCalled(t, "SetToken")
 }
 
 func TestEngine_ProcessToken_VaultWriteFails_StateTracked(t *testing.T) {

--- a/test/e2e/testdata/config-self-rotate.yaml
+++ b/test/e2e/testdata/config-self-rotate.yaml
@@ -1,0 +1,25 @@
+daemon:
+  mode: "one-shot"
+  dry_run: false
+
+rotation:
+  threshold_percent: 10
+
+vault:
+  address: "http://localhost:8200"
+  role_id: "${VAULT_ROLE_ID}"
+  secret_id: "${VAULT_SECRET_ID}"
+  mount_path: "secret"
+
+observability:
+  log_level: "info"
+
+tokens:
+  - label: "e2e-test-self-rotate"
+    team: "test-team"
+    validity: "90d"
+    scopes: "*"
+    self: true
+    storage:
+      - type: "vault"
+        path: "secret/data/e2e/test-self-rotate"


### PR DESCRIPTION
## Description

This commit adds the ability for `latr` to manage it's own Linode API token, designated in the configuration file by `self: true`. The intent here is to get around the chicken-egg problem (as well as having to remember to rotate the token manually). 

If a token is marked `self: true` and is within the rotation window, this token will be rotated using the existing `LINODE_TOKEN` specified at start time. After creation & storing it in Vault, we recreate the Linode API client to use the newly created token. This is meant to prevent needing to have some sort of job running that regularly pulls in the token from Vault and restarts `latr`. 

We _could_ just do an Argo PostSync hook or maybe a cron that checks to see if the secret has been changed recently (meaning it was rotated), but feels gross and I think this solution will be useful for others. 