### PR TITLE
feat(ref): multi-account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ A Go application for automatically managing and rotating Linode API tokens with 
 - **Automatic Token Rotation**: Automatically rotates tokens based on configurable thresholds (default: 10% validity remaining)
 - **Secure Storage**: Stores rotated tokens in HashiCorp Vault (KV v2)
 - **State Tracking**: Tracks token rotation history and state via Vault metadata
-- **Graceful Token Management**: Keeps old tokens until expiration (configurable pruning)
+- **Graceful Token Management**: Keeps old tokens until the Linode API auto-expires them
+- **Multi-Account Support**: Manage tokens across multiple Linode accounts with separate API credentials
+- **Account Token Management**: Optionally rotate the account's own API token
 - **Multiple Tokens**: Manage multiple API tokens with different configurations
 - **Team Metadata**: Associate tokens with owning teams for organization
-- **Flexible Configuration**: Single YAML file or glob pattern support
+- **Flexible Configuration**: Single YAML file or glob pattern for multi-account setups
+- **Custom API Endpoints**: Override the Linode API URL per account (e.g., for staging)
 - **Daemon or One-Shot**: Run as a long-running daemon or one-time execution
 - **Dry-Run Mode**: Test configuration without making changes
 - **OpenTelemetry Support**: Observability via traces, metrics, and logs
@@ -110,22 +113,44 @@ go install ./cmd/latr
 
 ## Configuration
 
-### Environment Variables
+latr supports single-file and multi-file configurations. In multi-file mode,
+a global config (`global: true`) provides defaults that account configs inherit
+and can override. Environment variables are expanded using `${VAR_NAME}` syntax.
 
-- `LINODE_TOKEN`: Your Linode API token (required)
+- `LINODE_TOKEN`: Your Linode API token (optional if in config)
 - `VAULT_ROLE_ID`: Vault AppRole role ID (optional if in config)
 - `VAULT_SECRET_ID`: Vault AppRole secret ID (optional if in config)
 
-### Configuration File
+### Credential Resolution
 
-Create a YAML configuration file (see `examples/config.yaml`):
+Credentials can be set at multiple levels. For each credential, latr checks
+in order: account config → global config → environment variable.
+
+| Credential | Account config | Global config | Env var |
+|---|---|---|---|
+| Linode API token | `account.token.storage` | — | `LINODE_TOKEN` |
+| Linode API URL | `account.api_url` | — | `LINODE_API_URL` |
+| Vault role ID | `account.vault.role_id` | `vault.role_id` | `VAULT_ROLE_ID` |
+| Vault secret ID | `account.vault.secret_id` | `vault.secret_id` | `VAULT_SECRET_ID` |
+
+If no source provides a required value (Linode token, Vault role/secret ID),
+latr exits with an error identifying which credential is missing and for
+which account. The Linode API URL defaults to `https://api.linode.com` if
+not set anywhere.
+
+### Single-File Configuration
+
+For simple setups with one Linode account, everything goes in a single file:
 
 ```yaml
-# Global daemon settings
-daemon:
-  mode: "daemon" # "daemon" or "one-shot"
-  check_interval: "30m" # How often to check tokens (daemon mode only)
-  dry_run: false # If true, no actual changes are made
+# Linode Account config (self)
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
 
 # Rotation behavior
 rotation:
@@ -151,7 +176,8 @@ tokens:
     scopes: "*" # "*" for all scopes, or comma-separated list
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/my-api-token"
+        path: "linode/tokens/my-api-token"
+        # key: "token"  # Optional: key name within the Vault secret (default: "token")
 
   - label: "backup-token"
     team: "sre-team"
@@ -160,8 +186,76 @@ tokens:
     rotation_threshold: 15 # Override global threshold for this token
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/backup"
+        path: "linode/tokens/backup"
 ```
+
+Storage entries support an optional `key` field that specifies the key name
+within the Vault KV v2 secret. It defaults to `"token"` if not set. The
+`account.token` storage uses `account.label` as the key automatically, which
+allows multiple accounts to share a single Vault path with separate keys.
+When a non-default key is used, token state metadata is tracked at a derived
+path to avoid collisions.
+
+### Multi-File Configuration
+
+For multiple accounts, use a global config for shared defaults and separate
+files per account. The global config is identified by `global: true` — file
+order doesn't matter. Only one global config is allowed.
+
+**Global config** (`global: true`) — shared defaults. Can optionally include
+`account` and `tokens` if it also serves as an account config (useful for
+single-file setups that need `global: true`):
+
+```yaml
+global: true
+
+daemon:
+  mode: "daemon"
+  check_interval: "30m"
+
+rotation:
+  threshold_percent: 10
+
+vault:
+  address: "https://vault.example.com"
+  role_id: "${VAULT_ROLE_ID}"
+  secret_id: "${VAULT_SECRET_ID}"
+  mount_path: "secret"
+
+observability:
+  log_level: "info"
+  otel_endpoint: "localhost:4317"
+```
+
+**Account configs** — inherit global defaults, override what's needed:
+
+```yaml
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  vault:
+    role_id: "account-specific-role-id"   # Overrides global vault.role_id
+    secret_id: "account-specific-secret"  # Overrides global vault.secret_id
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+
+tokens:
+  - label: "my-api-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "linode/tokens/my-api-token"
+```
+
+Account configs can also override `rotation` and `vault` settings from the
+global config. Any field not specified is inherited from the global
+defaults. Observability and daemon settings (`observability`, `mode`,
+`check_interval`, `dry_run`) are global-only — any per-account values for
+these fields are currently ignored and have no effect (a warning is logged
+if they differ from the global values).
 
 ## Usage
 
@@ -199,13 +293,88 @@ daemon:
   dry_run: true
 ```
 
-### Multiple Configuration Files
+### Multiple Accounts
 
-Use a glob pattern to load multiple config files:
+Use a glob pattern to load a global config and per-account configs:
 
 ```bash
 ./latr -config "configs/*.yaml"
 ```
+
+```
+configs/
+├── globals.yaml       # global: true — shared defaults
+├── production.yaml    # account + tokens (inherits globals)
+└── staging.yaml       # account + tokens (inherits globals, overrides as needed)
+```
+
+**configs/globals.yaml:**
+
+```yaml
+global: true
+
+daemon:
+  mode: "daemon"
+  check_interval: "30m"
+
+vault:
+  address: "https://vault.example.com"
+  role_id: "${VAULT_ROLE_ID}"
+  secret_id: "${VAULT_SECRET_ID}"
+```
+
+**configs/production.yaml:**
+
+```yaml
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  vault:
+    role_id: "prod-role-id"     # Override global credentials
+    secret_id: "prod-secret-id"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+
+tokens:
+  - label: "linode-api"
+    validity: "180d"
+    scopes: "linodes:read_write"
+    storage:
+      - type: "vault"
+        path: "prod/linode-api"
+```
+
+**configs/staging.yaml:**
+
+```yaml
+account:
+  label: "lcid-5678"
+  team: "platform-team"
+  api_url: "https://api.staging.example.com"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+
+# No account.vault — inherits global vault credentials
+
+rotation:
+  threshold_percent: 20  # Override: rotate earlier in staging
+
+tokens:
+  - label: "staging-api"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "staging/api"
+```
+
+All tokens in a configuration file use that file's account credentials. Tokens
+from `production.yaml` are rotated using the production account's API token;
+tokens from `staging.yaml` use the staging account's token.
 
 ### Version Information
 
@@ -226,10 +395,19 @@ Use a glob pattern to load multiple config files:
    - Previous token ID and expiry
    - Rotation count and timestamp
 
+### Account Token Management
+
+The `account.token` field optionally configures latr to rotate the account's own
+API token — the one configured in `account.token`. When rotation occurs,
+the new token is stored in Vault. The old token remains valid until Linode
+auto-expires it. The operator is responsible for restarting latr to pick up the
+new token (e.g., via ArgoCD syncing a ConfigMap update).
+
 ### Important Behaviors
 
 - **Automatic cleanup**: Expired tokens are automatically pruned by the Linode API - no manual cleanup needed
 - **Only manages configured tokens**: Only rotates tokens specified in the configuration
+- **Account isolation**: Each config file's tokens are managed using that file's account credentials
 - **Vault retry on failure**: If Linode succeeds but Vault fails, state is tracked for retry on next run
 - **Graceful shutdown**: Handles SIGTERM/SIGINT for clean daemon shutdown
 
@@ -363,7 +541,8 @@ Structured logging with rotation events, errors, and state changes
 
 ## Security Considerations
 
-- Store `LINODE_TOKEN` securely (env var, secrets manager)
+- Use `account.token.storage` to avoid plaintext tokens in config files
+- If using plain string form, store the value securely (env var expansion, K8s secrets)
 - Use Vault AppRole with minimal required permissions
 - Enable TLS for Vault communication in production
 - Rotate Vault AppRole secret IDs regularly
@@ -372,7 +551,7 @@ Structured logging with rotation events, errors, and state changes
 ## Roadmap
 
 - [x] Add proper tracing with OTel (<https://github.com/wbh1/latr/pull/11>)
-- [ ] Use structured logging (<https://github.com/wbh1/latr/issues/16>)
+- [x] Use structured logging (<https://github.com/wbh1/latr/issues/16>)
 - [ ] Additional storage backends (<https://github.com/wbh1/latr/issues/17>)
 - [x] Prometheus metrics exporter (<https://github.com/wbh1/latr/pull/11>)
 - [x] Integration tests with Docker Compose (<https://github.com/wbh1/latr/pull/2>)

--- a/cmd/latr/main.go
+++ b/cmd/latr/main.go
@@ -66,18 +66,13 @@ func main() {
 		primaryCfg = configs[0]
 	}
 
-	// Daemon and observability settings are global-only — enforce by overwriting on all non-global configs
+	// Daemon and observability settings are global-only — enforce by overwriting
+	// on all non-primary configs. We don't warn here because ApplyDefaults()
+	// populates these fields before we can distinguish "explicitly set" from
+	// "defaulted", which would cause misleading warnings.
 	for _, cfg := range configs {
 		if cfg != primaryCfg {
-			if cfg.Daemon != primaryCfg.Daemon {
-				logger.Warn("Per-account daemon settings are ignored; using global/primary values",
-					slog.String("account_label", cfg.Account.Label))
-			}
 			cfg.Daemon = primaryCfg.Daemon
-			if cfg.Observability != primaryCfg.Observability {
-				logger.Warn("Per-account observability settings are ignored; using global/primary values",
-					slog.String("account_label", cfg.Account.Label))
-			}
 			cfg.Observability = primaryCfg.Observability
 		}
 	}
@@ -203,10 +198,6 @@ func run(primaryCfg *config.Config, configs []*config.Config) error {
 					break
 				}
 			}
-		}
-		if linodeToken == "" && cfg.Account.Token != nil && cfg.Account.Token.HasStorage() {
-			logger.WarnContext(ctx, "account.token.storage is configured but no supported storage type was found; falling back to LINODE_TOKEN env var",
-				slog.String("account_label", acctLabel))
 		}
 		if linodeToken == "" {
 			linodeToken = os.Getenv("LINODE_TOKEN")

--- a/cmd/latr/main.go
+++ b/cmd/latr/main.go
@@ -46,74 +46,202 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Load Linode API token from environment
-	linodeToken := os.Getenv("LINODE_TOKEN")
-	if linodeToken == "" {
-		logger.Error("Missing required environment variable", slog.String("variable", "LINODE_TOKEN"))
-		os.Exit(1)
-	}
-
-	// Load and validate configuration
+	// Load and validate configuration(s)
 	logger.Info("Loading configuration", slog.String("path", *configPath))
-	cfg, err := config.LoadAndValidate(*configPath)
+	configs, err := config.LoadAndValidate(*configPath)
 	if err != nil {
 		logger.Error("Failed to load configuration", slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	logger.Info("Configuration loaded successfully",
-		slog.String("mode", cfg.Daemon.Mode),
-		slog.Int("token_count", len(cfg.Tokens)),
-		slog.Int("rotation_threshold_percent", cfg.Rotation.ThresholdPercent),
-		slog.Bool("dry_run", cfg.Daemon.DryRun))
+	// Use global settings from the global config, falling back to the first config
+	var primaryCfg *config.Config
+	for _, cfg := range configs {
+		if cfg.IsGlobal() {
+			primaryCfg = cfg
+			break
+		}
+	}
+	if primaryCfg == nil {
+		primaryCfg = configs[0]
+	}
+
+	// Daemon and observability settings are global-only — enforce by overwriting on all non-global configs
+	for _, cfg := range configs {
+		if cfg != primaryCfg {
+			if cfg.Daemon != primaryCfg.Daemon {
+				logger.Warn("Per-account daemon settings are ignored; using global/primary values",
+					slog.String("account_label", cfg.Account.Label))
+			}
+			cfg.Daemon = primaryCfg.Daemon
+			if cfg.Observability != primaryCfg.Observability {
+				logger.Warn("Per-account observability settings are ignored; using global/primary values",
+					slog.String("account_label", cfg.Account.Label))
+			}
+			cfg.Observability = primaryCfg.Observability
+		}
+	}
+
+	// Log each loaded configuration
+	var totalTokens int
+	for i, cfg := range configs {
+		tokenCount := len(cfg.AllTokens())
+		totalTokens += tokenCount
+		logger.Info("Configuration loaded",
+			slog.Int("config", i+1),
+			slog.String("account_label", cfg.Account.Label),
+			slog.Int("token_count", tokenCount))
+	}
+
+	// Log summary if multiple configs
+	if len(configs) > 1 {
+		accountCount := 0
+		for _, cfg := range configs {
+			if !cfg.IsGlobal() {
+				accountCount++
+			}
+		}
+		logger.Info("All configurations loaded",
+			slog.Int("account_count", accountCount),
+			slog.Int("total_token_count", totalTokens),
+			slog.String("mode", primaryCfg.Daemon.Mode),
+			slog.Int("rotation_threshold_percent", primaryCfg.Rotation.ThresholdPercent),
+			slog.Bool("dry_run", primaryCfg.Daemon.DryRun))
+	}
+
+	if err := run(primaryCfg, configs); err != nil {
+		logger.Error("Fatal error", slog.Any("error", err))
+		os.Exit(1)
+	}
+}
+
+// run handles telemetry setup, client initialization, and scheduling. Extracted
+// from main so that deferred cleanup functions (telemetry flush, context cancel)
+// execute on all exit paths.
+func run(primaryCfg *config.Config, configs []*config.Config) error {
+	logger := observability.GetLogger()
 
 	// Set up context with signal handling for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Initialize OpenTelemetry
 	telemetryConfig := &observability.Config{
 		ServiceName:  "latr",
-		OTelEndpoint: cfg.Observability.OTelEndpoint,
-		Enabled:      cfg.Observability.OTelEndpoint != "",
-		LogLevel:     cfg.Observability.LogLevel,
+		OTelEndpoint: primaryCfg.Observability.OTelEndpoint,
+		Enabled:      primaryCfg.Observability.OTelEndpoint != "",
+		LogLevel:     primaryCfg.Observability.LogLevel,
 	}
 
 	telemetryCleanup, err := observability.Setup(ctx, telemetryConfig)
 	if err != nil {
-		logger.ErrorContext(ctx, "Failed to initialize telemetry", slog.Any("error", err))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 	logger = observability.GetLogger()
 	defer telemetryCleanup()
 
-	// Create Linode client
-	linodeClient := linode.NewClient(linodeToken)
-	logger.InfoContext(ctx, "Linode client initialized")
+	// Create per-account entries (each account gets its own Vault + Linode client)
+	accounts := make([]scheduler.AccountEntry, 0, len(configs))
+	for _, cfg := range configs {
+		// Skip globals-only configs (no account, just defaults)
+		if cfg.Account.Label == "" {
+			continue
+		}
 
-	// Create Vault client
-	vaultConfig := &vault.Config{
-		Address:   cfg.Vault.Address,
-		RoleID:    cfg.Vault.RoleID,
-		SecretID:  cfg.Vault.SecretID,
-		MountPath: cfg.Vault.MountPath,
+		acctLabel := cfg.Account.Label
+
+		// Resolve Vault config: account.vault overrides global vault, then env var fallback
+		resolvedVault := cfg.Account.Vault.Resolved(cfg.Vault)
+
+		if resolvedVault.RoleID == "" {
+			resolvedVault.RoleID = os.Getenv("VAULT_ROLE_ID")
+		}
+		if resolvedVault.RoleID == "" {
+			return fmt.Errorf("account %q: vault role_id not set in config or VAULT_ROLE_ID env var", acctLabel)
+		}
+
+		if resolvedVault.SecretID == "" {
+			resolvedVault.SecretID = os.Getenv("VAULT_SECRET_ID")
+		}
+		if resolvedVault.SecretID == "" {
+			return fmt.Errorf("account %q: vault secret_id not set in config or VAULT_SECRET_ID env var", acctLabel)
+		}
+
+		vaultConfig := &vault.Config{
+			Address:   resolvedVault.Address,
+			RoleID:    resolvedVault.RoleID,
+			SecretID:  resolvedVault.SecretID,
+			MountPath: resolvedVault.MountPath,
+		}
+
+		vaultClient, err := vault.NewClient(vaultConfig)
+		if err != nil {
+			return fmt.Errorf("account %q: failed to create Vault client (address: %s): %w", acctLabel, resolvedVault.Address, err)
+		}
+		logger.InfoContext(ctx, "Vault client initialized for account",
+			slog.String("account_label", acctLabel),
+			slog.String("vault_address", resolvedVault.Address))
+
+		// Resolve Linode API token: account.token.storage first, then env var fallback
+		var linodeToken string
+		if cfg.Account.Token != nil && cfg.Account.Token.HasStorage() {
+			for _, s := range cfg.Account.Token.Storage {
+				if s.Type == "vault" {
+					vaultKey := acctLabel
+					if s.Key != "" {
+						vaultKey = s.Key
+					}
+					logger.InfoContext(ctx, "Reading Linode token from Vault",
+						slog.String("account_label", acctLabel),
+						slog.String("vault_path", s.Path),
+						slog.String("vault_key", vaultKey))
+
+					linodeToken, err = vaultClient.ReadSecretKey(ctx, s.Path, vaultKey)
+					if err != nil {
+						return fmt.Errorf("account %q: failed to read Linode token from Vault (path: %s): %w", acctLabel, s.Path, err)
+					}
+					break
+				}
+			}
+		}
+		if linodeToken == "" && cfg.Account.Token != nil && cfg.Account.Token.HasStorage() {
+			logger.WarnContext(ctx, "account.token.storage is configured but no supported storage type was found; falling back to LINODE_TOKEN env var",
+				slog.String("account_label", acctLabel))
+		}
+		if linodeToken == "" {
+			linodeToken = os.Getenv("LINODE_TOKEN")
+		}
+		if linodeToken == "" {
+			return fmt.Errorf("account %q: linode token not available from account.token.storage or LINODE_TOKEN env var", acctLabel)
+		}
+
+		// Resolve Linode API URL: config api_url takes precedence, then LINODE_API_URL env var
+		linodeAPIURL := cfg.Account.APIURL
+		if linodeAPIURL == "" {
+			linodeAPIURL = os.Getenv("LINODE_API_URL")
+		}
+
+		linodeClient := linode.NewClient(linodeToken, linodeAPIURL)
+		engine := rotation.NewEngine(linodeClient, vaultClient, primaryCfg.Daemon.DryRun)
+
+		tokens := cfg.AllTokens()
+
+		logger.InfoContext(ctx, "Initialized account",
+			slog.String("account_label", cfg.Account.Label),
+			slog.String("account_team", cfg.Account.Team),
+			slog.String("api_url", linodeAPIURL),
+			slog.Int("token_count", len(tokens)))
+
+		accounts = append(accounts, scheduler.AccountEntry{
+			Account:  cfg.Account,
+			Tokens:   tokens,
+			Engine:   engine,
+			Rotation: cfg.Rotation,
+		})
 	}
-
-	vaultClient, err := vault.NewClient(vaultConfig)
-	if err != nil {
-		logger.ErrorContext(ctx, "Failed to create Vault client",
-			slog.Any("error", err),
-			slog.String("vault_address", cfg.Vault.Address))
-		os.Exit(1)
-	}
-	logger.InfoContext(ctx, "Vault client initialized and authenticated",
-		slog.String("vault_address", cfg.Vault.Address))
-
-	// Create rotation engine
-	engine := rotation.NewEngine(linodeClient, vaultClient, cfg.Daemon.DryRun)
 
 	// Create scheduler
-	sched := scheduler.NewScheduler(cfg, engine)
-	defer cancel()
+	sched := scheduler.NewScheduler(primaryCfg.Daemon, accounts)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
@@ -133,11 +261,11 @@ func main() {
 	if err := sched.Run(ctx); err != nil {
 		if err == context.Canceled {
 			logger.Info("Shutdown complete")
-			os.Exit(0)
+			return nil
 		}
-		logger.Error("Scheduler error", slog.Any("error", err))
-		os.Exit(1)
+		return fmt.Errorf("scheduler error: %w", err)
 	}
 
 	logger.Info("latr finished successfully")
+	return nil
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,6 +1,41 @@
-# Example configuration for Linode API Token Rotator (latr)
+# Example single-file configuration for Linode API Token Rotator (latr)
+#
+# This file shows a complete single-file setup. For multi-file setups with
+# a global config and per-account configs, see examples/multi-account/.
 
-# Global daemon settings
+# Account configuration (required unless global: true)
+account:
+  label: "lcid-1234" # Identifies this account; used as the key when reading/writing via storage
+  team: "platform-team" # Team that owns this account
+
+  # Per-account Vault AppRole credentials (optional — falls back to global vault config, then env vars)
+  # vault:
+  #   role_id: "account-specific-role-id"
+  #   secret_id: "account-specific-secret-id"
+  #   address: "https://other-vault.example.com"   # Override global vault address
+  #   mount_path: "custom-mount"                    # Override global vault mount path
+
+  # api_url: "https://api.staging.example.com" # Override API endpoint (default: https://api.linode.com)
+
+  # Account token configuration (optional).
+  # If storage is set, the Linode API token is read from storage at startup.
+  # Key within the secret is derived from account.label.
+  # If not set, the LINODE_TOKEN environment variable is used.
+  #
+  # If label/validity/scopes are also set, latr manages (rotates) this token.
+  # Storage is required for managed tokens — the rotated token is written back
+  # to the same path using account.label as the key.
+  # The operator is responsible for restarting latr to pick up the new token.
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+    # Uncomment to enable rotation management:
+    # label: "latr-main-token"
+    # validity: "180d"
+    # scopes: "*"
+
+# Daemon settings
 daemon:
   mode: "daemon" # "daemon" or "one-shot"
   check_interval: "30m" # How often to check tokens (daemon mode only)
@@ -10,12 +45,11 @@ daemon:
 rotation:
   threshold_percent: 10 # Rotate when <=10% of validity remains
 
-# Vault configuration
-# Environment variables are automatically expanded using ${VAR_NAME} or $VAR_NAME syntax
+# Vault configuration (global defaults — can be overridden per-account)
 vault:
   address: "https://vault.example.com"
-  role_id: "${VAULT_ROLE_ID}" # Expanded from VAULT_ROLE_ID environment variable
-  secret_id: "${VAULT_SECRET_ID}" # Expanded from VAULT_SECRET_ID environment variable
+  role_id: "${VAULT_ROLE_ID}" # Expanded from environment variable
+  secret_id: "${VAULT_SECRET_ID}" # Expanded from environment variable
   mount_path: "secret" # KV v2 mount path
 
 # Observability settings
@@ -31,7 +65,8 @@ tokens:
     scopes: "*" # "*" for all scopes, or comma-separated list
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/my-api-token"
+        path: "linode/tokens/my-api-token"
+        # key: "token"  # Optional: key name within the Vault secret (default: "token")
 
   - label: "backup-token"
     team: "sre-team"
@@ -40,12 +75,4 @@ tokens:
     rotation_threshold: 15 # Override global threshold for this token
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/backup"
-
-  - label: "short-lived-token"
-    team: "dev-team"
-    validity: "7d"
-    scopes: "linodes:read_write"
-    storage:
-      - type: "vault"
-        path: "secret/data/linode/tokens/dev"
+        path: "linode/tokens/backup"

--- a/examples/multi-account/globals.yaml
+++ b/examples/multi-account/globals.yaml
@@ -1,0 +1,20 @@
+# Global configuration — shared defaults for all accounts.
+# This file is identified by global: true. File order doesn't matter.
+global: true
+
+daemon:
+  mode: "daemon"
+  check_interval: "30m"
+  dry_run: false
+
+rotation:
+  threshold_percent: 10
+
+vault:
+  address: "https://vault.example.com"
+  role_id: "${VAULT_ROLE_ID}"
+  secret_id: "${VAULT_SECRET_ID}"
+  mount_path: "secret"
+
+observability:
+  log_level: "info"

--- a/examples/multi-account/production.yaml
+++ b/examples/multi-account/production.yaml
@@ -1,0 +1,26 @@
+# Production account configuration.
+# Inherits daemon, rotation, vault, and observability from globals.yaml.
+
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  vault:
+    role_id: "prod-role-id"       # Override global credentials for this account
+    secret_id: "prod-secret-id"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+    # Managed — latr will rotate this token
+    label: "latr-prod-main"
+    validity: "180d"
+    scopes: "*"
+
+tokens:
+  - label: "prod-api-token"
+    team: "platform-team"
+    validity: "90d"
+    scopes: "linodes:read_write"
+    storage:
+      - type: "vault"
+        path: "linode/tokens/prod-api"

--- a/examples/multi-account/staging.yaml
+++ b/examples/multi-account/staging.yaml
@@ -1,0 +1,25 @@
+# Staging account configuration.
+# Inherits defaults from globals.yaml. Overrides rotation threshold
+# and uses a different API endpoint.
+
+account:
+  label: "lcid-5678"
+  team: "platform-team"
+  api_url: "https://api.staging.example.com"
+  # No account.vault — inherits global vault credentials
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+
+rotation:
+  threshold_percent: 20  # Rotate earlier in staging
+
+tokens:
+  - label: "staging-api-token"
+    team: "platform-team"
+    validity: "30d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "linode/tokens/staging-api"

--- a/helm/latr/README.md
+++ b/helm/latr/README.md
@@ -23,18 +23,31 @@ latr is an automation tool that manages and automatically rotates Linode API tok
 
 ```bash
 helm install latr ./helm/latr \
-  --set secrets.linodeToken="your-linode-token" \
+  --set config.account.label="lcid-1234" \
   --set secrets.vaultRoleId="your-vault-role-id" \
   --set secrets.vaultSecretId="your-vault-secret-id" \
+  --set secrets.linodeToken="your-linode-token" \
   --set config.vault.address="https://vault.example.com:8200"
 ```
 
-### Installation with Custom Values
+### Installation with Vault Token Source (Recommended)
+
+When using `account.token.storage`, the Linode API token is read from Vault at
+startup, so the Linode API token itself is not stored in plaintext in config or
+K8s Secrets. Vault AppRole credentials are still managed via K8s Secrets.
 
 Create a `custom-values.yaml` file:
 
 ```yaml
 config:
+  account:
+    label: "lcid-1234"
+    team: "platform-team"
+    token:
+      storage:
+        - type: vault
+          path: "linode/accounts"
+
   vault:
     address: "https://vault.example.com:8200"
 
@@ -45,7 +58,34 @@ config:
       scopes: "*"
       storage:
         - type: "vault"
-          path: "secret/data/linode/tokens/production"
+          path: "linode/tokens/production"
+
+secrets:
+  vaultRoleId: "your-vault-role-id"
+  vaultSecretId: "your-vault-secret-id"
+```
+
+### Installation with LINODE_TOKEN Env Var
+
+If not using `account.token.storage`, the `LINODE_TOKEN` env var is used:
+
+```yaml
+config:
+  account:
+    label: "production"
+    team: "platform-team"
+
+  vault:
+    address: "https://vault.example.com:8200"
+
+  tokens:
+    - label: "production-api-token"
+      team: "platform-team"
+      validity: "90d"
+      scopes: "*"
+      storage:
+        - type: "vault"
+          path: "linode/tokens/production"
 
 secrets:
   linodeToken: "your-linode-token"
@@ -134,6 +174,19 @@ The following table lists the configurable parameters of the latr chart and thei
 | `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
 | `podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
 
+### Account Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.account.label` | Account label (required). Also used as storage key | `""` |
+| `config.account.team` | Team that owns this account | `""` |
+| `config.account.vault.roleId` | Vault AppRole role ID for this account | `"${VAULT_ROLE_ID}"` |
+| `config.account.vault.secretId` | Vault AppRole secret ID for this account | `"${VAULT_SECRET_ID}"` |
+| `config.account.vault.address` | Override global Vault address for this account | `""` |
+| `config.account.vault.mountPath` | Override global Vault mount path for this account | `""` |
+| `config.account.apiUrl` | Linode API URL override | `""` (uses `https://api.linode.com`) |
+| `config.account.token` | Account token config — storage source + optional rotation | `{}` |
+
 ### latr Configuration Parameters
 
 | Parameter | Description | Default |
@@ -142,12 +195,16 @@ The following table lists the configurable parameters of the latr chart and thei
 | `config.daemon.checkInterval` | Check interval for daemon mode | `30m` |
 | `config.daemon.dryRun` | Enable dry-run mode | `false` |
 | `config.rotation.thresholdPercent` | Rotation threshold percentage | `10` |
-| `config.rotation.pruneExpired` | Prune expired tokens | `false` |
-| `config.vault.address` | Vault server address | `""` |
-| `config.vault.mountPath` | Vault KV v2 mount path | `secret` |
+| `config.vault.address` | Global Vault server address | `""` |
+| `config.vault.mountPath` | Global Vault KV v2 mount path | `secret` |
 | `config.observability.otelEndpoint` | OpenTelemetry endpoint | `""` |
 | `config.observability.logLevel` | Log level | `info` |
-| `config.tokens` | Token configurations (list) | `[]` |
+| `config.tokens` | Token configurations (list, uses snake_case — see below) | `[]` |
+
+> **Note:** `config.tokens` and `config.account.token` are rendered into the
+> latr config file via `toYaml`, so their fields must use **snake_case** to
+> match the application's YAML tags (e.g., `rotation_threshold`, not
+> `rotationThreshold`).
 
 ### Secrets Parameters
 
@@ -174,12 +231,20 @@ The following table lists the configurable parameters of the latr chart and thei
 
 ## Examples
 
-### Example 1: Basic Daemon Mode
+### Example 1: Basic Daemon Mode with Vault Token Source
 
-Deploy latr in daemon mode with a single token:
+Deploy latr in daemon mode, reading the Linode API token from Vault:
 
 ```yaml
 config:
+  account:
+    label: "lcid-1234"
+    team: "platform"
+    token:
+      storage:
+        - type: vault
+          path: "linode/accounts"
+
   daemon:
     mode: daemon
     checkInterval: "1h"
@@ -194,10 +259,9 @@ config:
       scopes: "*"
       storage:
         - type: "vault"
-          path: "secret/data/linode/tokens/my-token"
+          path: "linode/tokens/my-token"
 
 secrets:
-  linodeToken: "your-linode-token"
   vaultRoleId: "your-vault-role-id"
   vaultSecretId: "your-vault-secret-id"
 ```
@@ -206,6 +270,14 @@ secrets:
 
 ```yaml
 config:
+  account:
+    label: "lcid-1234"
+    team: "platform"
+    token:
+      storage:
+        - type: vault
+          path: "linode/accounts"
+
   vault:
     address: "https://vault.example.com:8200"
 
@@ -214,25 +286,33 @@ config:
       team: "platform"
       validity: "90d"
       scopes: "*"
-      rotationThreshold: 10
+      rotation_threshold: 10
       storage:
         - type: "vault"
-          path: "secret/data/linode/tokens/prod-full"
+          path: "linode/tokens/prod-full"
 
     - label: "dev-limited-access"
       team: "development"
       validity: "30d"
       scopes: "linodes:read_only,images:read_only"
-      rotationThreshold: 20
+      rotation_threshold: 20
       storage:
         - type: "vault"
-          path: "secret/data/linode/tokens/dev-limited"
+          path: "linode/tokens/dev-limited"
 ```
 
 ### Example 3: With OpenTelemetry
 
 ```yaml
 config:
+  account:
+    label: "lcid-1234"
+    team: "ops"
+    token:
+      storage:
+        - type: vault
+          path: "linode/accounts"
+
   vault:
     address: "https://vault.example.com:8200"
 
@@ -247,7 +327,7 @@ config:
       scopes: "*"
       storage:
         - type: "vault"
-          path: "secret/data/linode/tokens/monitored"
+          path: "linode/tokens/monitored"
 ```
 
 ### Example 4: High Availability Setup

--- a/helm/latr/templates/configmap.yaml
+++ b/helm/latr/templates/configmap.yaml
@@ -6,6 +6,28 @@ metadata:
     {{- include "latr.labels" . | nindent 4 }}
 data:
   config.yaml: |
+    account:
+      label: {{ .Values.config.account.label | quote }}
+      {{- if .Values.config.account.team }}
+      team: {{ .Values.config.account.team | quote }}
+      {{- end }}
+      vault:
+        role_id: {{ if .Values.config.account.vault.roleId }}{{ .Values.config.account.vault.roleId | quote }}{{ else }}"${VAULT_ROLE_ID}"{{ end }}
+        secret_id: {{ if .Values.config.account.vault.secretId }}{{ .Values.config.account.vault.secretId | quote }}{{ else }}"${VAULT_SECRET_ID}"{{ end }}
+        {{- if .Values.config.account.vault.address }}
+        address: {{ .Values.config.account.vault.address | quote }}
+        {{- end }}
+        {{- if .Values.config.account.vault.mountPath }}
+        mount_path: {{ .Values.config.account.vault.mountPath | quote }}
+        {{- end }}
+      {{- if .Values.config.account.apiUrl }}
+      api_url: {{ .Values.config.account.apiUrl | quote }}
+      {{- end }}
+      {{- if .Values.config.account.token }}
+      token:
+        {{- toYaml .Values.config.account.token | nindent 8 }}
+      {{- end }}
+
     daemon:
       mode: {{ .Values.config.daemon.mode }}
       check_interval: {{ .Values.config.daemon.checkInterval | quote }}
@@ -13,12 +35,9 @@ data:
 
     rotation:
       threshold_percent: {{ .Values.config.rotation.thresholdPercent }}
-      prune_expired: {{ .Values.config.rotation.pruneExpired }}
 
     vault:
       address: {{ .Values.config.vault.address | quote }}
-      role_id: "${VAULT_ROLE_ID}"
-      secret_id: "${VAULT_SECRET_ID}"
       mount_path: {{ .Values.config.vault.mountPath | quote }}
 
     observability:

--- a/helm/latr/values.yaml
+++ b/helm/latr/values.yaml
@@ -78,6 +78,46 @@ podDisruptionBudget:
 
 # latr application configuration
 config:
+  # Configuration for a single-account deployment via this Helm chart.
+  # For multi-account setups, use Kustomize overlays with separate config files.
+
+  # Account configuration (required for this chart)
+  account:
+    # Label for this account (required). Also used as the Vault key when
+    # using storage-based token source.
+    label: ""
+    # Team that owns this account
+    team: ""
+    # Vault AppRole credentials for this account
+    vault:
+      roleId: ""
+      secretId: ""
+      # Optional overrides for global vault.address and vault.mountPath:
+      # address: ""
+      # mountPath: ""
+    # Linode API URL (optional, defaults to https://api.linode.com)
+    apiUrl: ""
+    # Account token configuration (optional) — passed directly via toYaml,
+    # so field names must use snake_case to match the Go YAML tags.
+    # If storage is set, the Linode API token is read from storage at startup
+    # (key derived from account.label). Falls back to LINODE_TOKEN env var.
+    # If label/validity/scopes are also set, latr manages (rotates) this token.
+    token: {}
+    # Example — read from vault, no rotation:
+    #   token:
+    #     storage:
+    #       - type: vault
+    #         path: "linode/accounts"
+    # Example — read from vault + managed rotation:
+    #   token:
+    #     storage:
+    #       - type: vault
+    #         path: "linode/accounts"
+    #     label: "latr-main"
+    #     validity: "180d"
+    #     scopes: "*"
+    #     rotation_threshold: 10
+
   # Daemon settings
   daemon:
     # Mode: "daemon" for continuous operation or "one-shot" for single execution
@@ -91,19 +131,13 @@ config:
   rotation:
     # Rotate when this percentage of validity remains (e.g., 10 = rotate at 10% remaining)
     thresholdPercent: 10
-    # Whether to prune (delete) expired tokens from Linode
-    pruneExpired: false
 
-  # Vault configuration
+  # Global Vault configuration (defaults — can be overridden per-account via account.vault)
   vault:
     # Vault server address (e.g., "https://vault.example.com:8200")
     address: ""
     # Vault mount path for KV v2 secrets engine
     mountPath: "secret"
-    # AppRole authentication credentials
-    # These reference Kubernetes secrets by default
-    roleId: ""
-    secretId: ""
 
   # Observability settings
   observability:
@@ -112,18 +146,20 @@ config:
     # Log level: debug, info, warn, error
     logLevel: "info"
 
-  # Token definitions
-  # At least one token must be defined
+  # Token definitions — passed directly to the latr config file via toYaml,
+  # so field names must use snake_case to match the Go YAML tags.
+  # At least one token must be defined.
   tokens: []
   # Example token configuration:
   # - label: my-api-token
   #   team: platform-team
   #   validity: 90d
   #   scopes: "*"
-  #   rotationThreshold: 10
+  #   rotation_threshold: 10
   #   storage:
   #     - type: vault
-  #       path: secret/data/linode/tokens/my-api-token
+  #       path: linode/tokens/my-api-token
+  #       key: ""  # Optional: key name within the Vault secret (default: "token")
 
 # Secrets configuration
 # These values should be provided via a separate values file or via --set flags

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -12,11 +13,96 @@ import (
 
 // Config represents the complete configuration for the token rotator
 type Config struct {
+	// Global marks this config as the global defaults file. When set to true,
+	// this config's daemon, vault, rotation, and observability settings serve
+	// as defaults for other configs. Account and tokens are optional — if
+	// present, this config is also processed as an account.
+	Global        bool                `yaml:"global"`
+	Account       AccountConfig       `yaml:"account"`
 	Daemon        DaemonConfig        `yaml:"daemon"`
 	Rotation      RotationConfig      `yaml:"rotation"`
 	Vault         VaultConfig         `yaml:"vault"`
 	Observability ObservabilityConfig `yaml:"observability"`
 	Tokens        []TokenConfig       `yaml:"tokens"`
+}
+
+// AccountConfig represents the Linode account used by this configuration file.
+// An account block with a label is required unless the config is global-only
+// (global: true with no account or tokens).
+type AccountConfig struct {
+	// Label identifies this account (e.g., "lcid-1234").
+	// Also used as the key when reading/writing the token via storage.
+	Label string `yaml:"label"`
+	// Team that owns this account
+	Team string `yaml:"team"`
+	// APIURL overrides the Linode API endpoint (default: https://api.linode.com)
+	APIURL string `yaml:"api_url"`
+	// Vault contains the AppRole credentials for this account, plus optional
+	// overrides for the global Vault address and mount path.
+	Vault AccountVaultConfig `yaml:"vault"`
+	// Token configures the account's Linode API token.
+	// If omitted, the LINODE_TOKEN environment variable is used.
+	// If storage is set, the token is read from storage at startup.
+	// If rotation fields (label, validity, scopes) are also set, latr will
+	// manage and rotate this token. The operator is responsible for
+	// restarting latr to pick up the new token after rotation.
+	Token *AccountTokenConfig `yaml:"token"`
+}
+
+// AccountTokenConfig configures the account's Linode API token source and
+// optional rotation management.
+//
+// Storage determines where the token is read from (and written back to after
+// rotation). If storage is not set, the LINODE_TOKEN env var is used.
+//
+// If Label, Validity, and Scopes are set, latr will manage this token's
+// lifecycle — rotating it like any other managed token. When managed, storage
+// is required so the rotated token can be written back. The key used within
+// storage is derived from account.label.
+type AccountTokenConfig struct {
+	Storage           []StorageConfig `yaml:"storage"`
+	Label             string          `yaml:"label"`
+	Validity          string          `yaml:"validity"`
+	Scopes            string          `yaml:"scopes"`
+	RotationThreshold int             `yaml:"rotation_threshold"`
+}
+
+// IsManaged returns true if the token is configured for rotation management.
+func (c *AccountTokenConfig) IsManaged() bool {
+	return c.Label != "" && c.Validity != "" && c.Scopes != ""
+}
+
+// HasStorage returns true if the token should be read from a storage backend.
+func (c *AccountTokenConfig) HasStorage() bool {
+	return len(c.Storage) > 0
+}
+
+// AccountVaultConfig contains per-account Vault credentials and optional
+// overrides for the global Vault address and mount path.
+type AccountVaultConfig struct {
+	RoleID    string `yaml:"role_id"`
+	SecretID  string `yaml:"secret_id"`
+	Address   string `yaml:"address"`    // Optional: overrides global vault.address
+	MountPath string `yaml:"mount_path"` // Optional: overrides global vault.mount_path
+}
+
+// Resolved returns a fully resolved VaultConfig by overlaying account-level
+// overrides on top of the global defaults.
+func (c *AccountVaultConfig) Resolved(global VaultConfig) VaultConfig {
+	resolved := global
+	if c.Address != "" {
+		resolved.Address = c.Address
+	}
+	if c.RoleID != "" {
+		resolved.RoleID = c.RoleID
+	}
+	if c.SecretID != "" {
+		resolved.SecretID = c.SecretID
+	}
+	if c.MountPath != "" {
+		resolved.MountPath = c.MountPath
+	}
+	return resolved
 }
 
 // DaemonConfig contains settings for daemon behavior
@@ -31,7 +117,9 @@ type RotationConfig struct {
 	ThresholdPercent int `yaml:"threshold_percent"`
 }
 
-// VaultConfig contains Vault connection and authentication settings
+// VaultConfig contains Vault connection and authentication settings.
+// These serve as global defaults. Per-account overrides can be set in
+// account.vault (AccountVaultConfig).
 type VaultConfig struct {
 	Address   string `yaml:"address"`
 	RoleID    string `yaml:"role_id"`
@@ -59,6 +147,8 @@ type TokenConfig struct {
 type StorageConfig struct {
 	Type string `yaml:"type"`
 	Path string `yaml:"path"`
+	// Key is the key name within the secret. Defaults to "token" if empty.
+	Key string `yaml:"key,omitempty"`
 }
 
 // Parse parses YAML configuration data into a Config struct.
@@ -105,28 +195,57 @@ func (c *Config) ApplyDefaults() {
 	if c.Observability.LogLevel == "" {
 		c.Observability.LogLevel = "info"
 	}
+	// Note: Account.APIURL is intentionally NOT defaulted here.
+	// An empty APIURL allows main.go to fall back to LINODE_API_URL env var.
+	// The linode client defaults to https://api.linode.com when both are empty.
 }
 
-// Validate checks that the configuration is valid
+// IsGlobal returns true if this config is marked as the global defaults file
+// via `global: true`. Global configs provide default settings for other configs
+// and may optionally include account and tokens.
+func (c *Config) IsGlobal() bool {
+	return c.Global
+}
+
+// Validate checks that the configuration is valid.
 func (c *Config) Validate() error {
-	// Validate Vault config
-	if c.Vault.Address == "" {
-		return fmt.Errorf("vault address is required")
-	}
-	if c.Vault.RoleID == "" {
-		return fmt.Errorf("vault role_id is required")
-	}
-	if c.Vault.SecretID == "" {
-		return fmt.Errorf("vault secret_id is required")
+	if c.Global && c.Account.Label == "" && len(c.Tokens) == 0 {
+		// Global-only config (no account or tokens) — just provides defaults.
+		return nil
 	}
 
-	// Validate tokens
-	if len(c.Tokens) == 0 {
-		return fmt.Errorf("at least one token must be configured")
+	// Validate account config
+	if c.Account.Label == "" {
+		return fmt.Errorf("account label is required")
+	}
+	if strings.Contains(c.Account.Label, "/") || strings.Contains(c.Account.Label, "..") {
+		return fmt.Errorf("account label must not contain '/' or '..' (got %q)", c.Account.Label)
+	}
+
+	// Validate Vault address is set somewhere (globally or per-account)
+	resolvedVault := c.Account.Vault.Resolved(c.Vault)
+	if resolvedVault.Address == "" {
+		return fmt.Errorf("vault address is required (set globally in vault.address or per-account in account.vault.address)")
+	}
+
+	// Note: account.vault.role_id and secret_id are resolved at runtime —
+	// they can come from the config file or VAULT_ROLE_ID / VAULT_SECRET_ID
+	// environment variables.
+
+	// Validate account token if configured
+	if c.Account.Token != nil {
+		if err := c.validateAccountToken(); err != nil {
+			return err
+		}
+	}
+
+	// Tokens list can be empty if managing the account token
+	if len(c.Tokens) == 0 && (c.Account.Token == nil || !c.Account.Token.IsManaged()) {
+		return fmt.Errorf("at least one token must be configured (in tokens list or as a managed account.token)")
 	}
 
 	for i, token := range c.Tokens {
-		if err := c.validateToken(&token, i); err != nil {
+		if err := validateToken(&token, fmt.Sprintf("token[%d]", i)); err != nil {
 			return err
 		}
 	}
@@ -134,33 +253,123 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) validateToken(token *TokenConfig, index int) error {
+func (c *Config) validateAccountToken() error {
+	t := c.Account.Token
+
+	// Validate storage entries if present
+	supportedStorageTypes := map[string]bool{"vault": true}
+	if t.HasStorage() {
+		for i, s := range t.Storage {
+			if s.Type == "" {
+				return fmt.Errorf("account.token.storage[%d]: type is required", i)
+			}
+			if !supportedStorageTypes[s.Type] {
+				return fmt.Errorf("account.token.storage[%d]: unsupported storage type %q (supported: vault)", i, s.Type)
+			}
+			if s.Path == "" {
+				return fmt.Errorf("account.token.storage[%d]: path is required", i)
+			}
+			if s.Key != "" && (strings.Contains(s.Key, "/") || strings.Contains(s.Key, "..")) {
+				return fmt.Errorf("account.token.storage[%d]: key must not contain '/' or '..' (got %q)", i, s.Key)
+			}
+		}
+	}
+
+	// If managed (has rotation fields), validate them
+	if t.IsManaged() {
+		if !t.HasStorage() {
+			return fmt.Errorf("account.token: managed token (with label/validity/scopes) requires storage so the rotated token can be written back")
+		}
+
+		duration, err := ParseValidityDuration(t.Validity)
+		if err != nil {
+			return fmt.Errorf("account.token: invalid validity period: %w", err)
+		}
+		maxValidity := 180 * 24 * time.Hour
+		if duration > maxValidity {
+			return fmt.Errorf("account.token: validity period must be <= 6 months (180d), got %s", t.Validity)
+		}
+	}
+
+	return nil
+}
+
+func validateToken(token *TokenConfig, prefix string) error {
 	if token.Label == "" {
-		return fmt.Errorf("token[%d]: token label is required", index)
+		return fmt.Errorf("%s: token label is required", prefix)
 	}
 	if token.Validity == "" {
-		return fmt.Errorf("token[%d]: token validity is required", index)
+		return fmt.Errorf("%s: token validity is required", prefix)
 	}
 	if token.Scopes == "" {
-		return fmt.Errorf("token[%d]: token scopes is required", index)
+		return fmt.Errorf("%s: token scopes is required", prefix)
 	}
 	if len(token.Storage) == 0 {
-		return fmt.Errorf("token[%d]: at least one storage backend is required", index)
+		return fmt.Errorf("%s: at least one storage backend is required", prefix)
+	}
+	supportedStorageTypes := map[string]bool{"vault": true}
+	for i, s := range token.Storage {
+		if s.Type == "" {
+			return fmt.Errorf("%s: storage[%d]: type is required", prefix, i)
+		}
+		if !supportedStorageTypes[s.Type] {
+			return fmt.Errorf("%s: storage[%d]: unsupported storage type %q (supported: vault)", prefix, i, s.Type)
+		}
+		if s.Path == "" {
+			return fmt.Errorf("%s: storage[%d]: path is required", prefix, i)
+		}
+		if s.Key != "" && (strings.Contains(s.Key, "/") || strings.Contains(s.Key, "..")) {
+			return fmt.Errorf("%s: storage[%d]: key must not contain '/' or '..' (got %q)", prefix, i, s.Key)
+		}
 	}
 
 	// Validate validity period
 	duration, err := ParseValidityDuration(token.Validity)
 	if err != nil {
-		return fmt.Errorf("token[%d]: invalid validity period: %w", index, err)
+		return fmt.Errorf("%s: invalid validity period: %w", prefix, err)
 	}
 
 	// Check that validity is <= 6 months (180 days)
 	maxValidity := 180 * 24 * time.Hour
 	if duration > maxValidity {
-		return fmt.Errorf("token[%d]: validity period must be <= 6 months (180d), got %s", index, token.Validity)
+		return fmt.Errorf("%s: validity period must be <= 6 months (180d), got %s", prefix, token.Validity)
 	}
 
 	return nil
+}
+
+// AllTokens returns all tokens for this config, including the account's own
+// token (if managed) prepended to the list. The account token's storage key
+// defaults to account.label so it reads/writes to the same location, but a
+// storage.key override is respected when provided.
+func (c *Config) AllTokens() []TokenConfig {
+	var tokens []TokenConfig
+	if c.Account.Token != nil && c.Account.Token.IsManaged() {
+		// Derive storage, respecting any explicit storage key and
+		// defaulting to account.label when none is set.
+		var storage []StorageConfig
+		for _, s := range c.Account.Token.Storage {
+			key := s.Key
+			if key == "" {
+				key = c.Account.Label
+			}
+			storage = append(storage, StorageConfig{
+				Type: s.Type,
+				Path: s.Path,
+				Key:  key,
+			})
+		}
+		tokens = append(tokens, TokenConfig{
+			Label:             c.Account.Token.Label,
+			Team:              c.Account.Team,
+			Validity:          c.Account.Token.Validity,
+			Scopes:            c.Account.Token.Scopes,
+			RotationThreshold: c.Account.Token.RotationThreshold,
+			Storage:           storage,
+		})
+	}
+	tokens = append(tokens, c.Tokens...)
+	return tokens
 }
 
 // ParseValidityDuration parses a validity string (e.g., "90d", "6mo") into a time.Duration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,8 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// helper to create a minimal valid account config for tests
+func testAccount() AccountConfig {
+	return AccountConfig{
+		Label: "production",
+		Vault: AccountVaultConfig{
+			RoleID:   "test-role-id",
+			SecretID: "test-secret-id",
+		},
+	}
+}
+
 func TestParseValidConfig(t *testing.T) {
 	yamlContent := `
+account:
+  label: "production"
+  team: "platform-team"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
 daemon:
   mode: "daemon"
   check_interval: "30m"
@@ -18,12 +36,9 @@ daemon:
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
   mount_path: "secret"
 
 observability:
@@ -37,95 +52,410 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	cfg, err := Parse([]byte(yamlContent))
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Check daemon settings
+	assert.Equal(t, "production", cfg.Account.Label)
+	assert.Equal(t, "platform-team", cfg.Account.Team)
+	assert.Equal(t, "test-role-id", cfg.Account.Vault.RoleID)
+	assert.Equal(t, "test-secret-id", cfg.Account.Vault.SecretID)
+	assert.Nil(t, cfg.Account.Token)
+
 	assert.Equal(t, "daemon", cfg.Daemon.Mode)
-	assert.Equal(t, "30m", cfg.Daemon.CheckInterval)
-	assert.False(t, cfg.Daemon.DryRun)
-
-	// Check rotation settings
-	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
-
-	// Check vault settings
 	assert.Equal(t, "https://vault.example.com", cfg.Vault.Address)
-	assert.Equal(t, "test-role-id", cfg.Vault.RoleID)
-	assert.Equal(t, "test-secret-id", cfg.Vault.SecretID)
 	assert.Equal(t, "secret", cfg.Vault.MountPath)
 
-	// Check observability settings
-	assert.Equal(t, "localhost:4317", cfg.Observability.OTelEndpoint)
-	assert.Equal(t, "info", cfg.Observability.LogLevel)
-
-	// Check tokens
 	require.Len(t, cfg.Tokens, 1)
-	token := cfg.Tokens[0]
-	assert.Equal(t, "test-token", token.Label)
-	assert.Equal(t, "platform-team", token.Team)
-	assert.Equal(t, "90d", token.Validity)
-	assert.Equal(t, "*", token.Scopes)
-	require.Len(t, token.Storage, 1)
-	assert.Equal(t, "vault", token.Storage[0].Type)
-	assert.Equal(t, "secret/data/linode/tokens/test", token.Storage[0].Path)
+	assert.Equal(t, "test-token", cfg.Tokens[0].Label)
 }
 
 func TestParseConfigWithDefaults(t *testing.T) {
 	yamlContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
 
 tokens:
   - label: "test-token"
-    team: "platform-team"
     validity: "90d"
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "path"
 `
 
 	cfg, err := Parse([]byte(yamlContent))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	// Apply defaults
 	cfg.ApplyDefaults()
 
-	// Check defaults were applied
 	assert.Equal(t, "daemon", cfg.Daemon.Mode)
 	assert.Equal(t, "30m", cfg.Daemon.CheckInterval)
-	assert.False(t, cfg.Daemon.DryRun)
 	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
 	assert.Equal(t, "secret", cfg.Vault.MountPath)
 	assert.Equal(t, "info", cfg.Observability.LogLevel)
+	assert.Equal(t, "", cfg.Account.APIURL)
 }
 
-func TestValidateConfig_ValidityPeriodTooLong(t *testing.T) {
+func TestParseConfigWithAccountToken_StorageOnly(t *testing.T) {
+	yamlContent := `
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "managed-token"
+    validity: "90d"
+    scopes: "linodes:read_write"
+    storage:
+      - type: "vault"
+        path: "linode/managed"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Account.Token)
+	assert.True(t, cfg.Account.Token.HasStorage())
+	assert.False(t, cfg.Account.Token.IsManaged())
+
+	// AllTokens should NOT include the account token (not managed)
+	allTokens := cfg.AllTokens()
+	require.Len(t, allTokens, 1)
+	assert.Equal(t, "managed-token", allTokens[0].Label)
+}
+
+func TestParseConfigWithAccountToken_Managed(t *testing.T) {
+	yamlContent := `
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+  api_url: "https://api.staging.example.com"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+    label: "latr-main"
+    validity: "180d"
+    scopes: "*"
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "managed-token"
+    validity: "90d"
+    scopes: "linodes:read_write"
+    storage:
+      - type: "vault"
+        path: "linode/managed"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://api.staging.example.com", cfg.Account.APIURL)
+	require.NotNil(t, cfg.Account.Token)
+	assert.True(t, cfg.Account.Token.IsManaged())
+	assert.True(t, cfg.Account.Token.HasStorage())
+
+	allTokens := cfg.AllTokens()
+	require.Len(t, allTokens, 2)
+	assert.Equal(t, "latr-main", allTokens[0].Label)
+	require.Len(t, allTokens[0].Storage, 1)
+	assert.Equal(t, "lcid-1234", allTokens[0].Storage[0].Key)
+	assert.Equal(t, "managed-token", allTokens[1].Label)
+}
+
+func TestAllTokens_RespectsStorageKeyOverride(t *testing.T) {
 	cfg := &Config{
-		Vault: VaultConfig{
-			Address:   "https://vault.example.com",
-			RoleID:    "test-role-id",
-			SecretID:  "test-secret-id",
-			MountPath: "secret",
-		},
-		Tokens: []TokenConfig{
-			{
-				Label:    "test-token",
-				Team:     "platform-team",
-				Validity: "7mo", // More than 6 months
+		Account: AccountConfig{
+			Label: "lcid-1234",
+			Team:  "platform-team",
+			Token: &AccountTokenConfig{
+				Storage:  []StorageConfig{{Type: "vault", Path: "linode/accounts", Key: "custom-key"}},
+				Label:    "latr-main",
+				Validity: "180d",
 				Scopes:   "*",
-				Storage: []StorageConfig{
-					{Type: "vault", Path: "secret/data/linode/tokens/test"},
-				},
 			},
 		},
+	}
+
+	allTokens := cfg.AllTokens()
+	require.Len(t, allTokens, 1)
+	assert.Equal(t, "custom-key", allTokens[0].Storage[0].Key, "should preserve explicit storage key")
+}
+
+func TestAllTokens_DefaultsKeyToAccountLabel(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "lcid-1234",
+			Team:  "platform-team",
+			Token: &AccountTokenConfig{
+				Storage:  []StorageConfig{{Type: "vault", Path: "linode/accounts"}},
+				Label:    "latr-main",
+				Validity: "180d",
+				Scopes:   "*",
+			},
+		},
+	}
+
+	allTokens := cfg.AllTokens()
+	require.Len(t, allTokens, 1)
+	assert.Equal(t, "lcid-1234", allTokens[0].Storage[0].Key, "should default to account label when key is empty")
+}
+
+func TestParseConfigAccountTokenOnly(t *testing.T) {
+	yamlContent := `
+account:
+  label: "lcid-1234"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+  token:
+    storage:
+      - type: "vault"
+        path: "linode/accounts"
+    label: "latr-main"
+    validity: "180d"
+    scopes: "*"
+
+vault:
+  address: "https://vault.example.com"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+	cfg.ApplyDefaults()
+
+	err = cfg.Validate()
+	require.NoError(t, err)
+
+	allTokens := cfg.AllTokens()
+	require.Len(t, allTokens, 1)
+	assert.Equal(t, "latr-main", allTokens[0].Label)
+	assert.Equal(t, "lcid-1234", allTokens[0].Storage[0].Key)
+}
+
+func TestParseConfigWithAccountVaultOverride(t *testing.T) {
+	yamlContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "account-role-id"
+    secret_id: "account-secret-id"
+    address: "https://account-vault.example.com"
+    mount_path: "custom-mount"
+
+vault:
+  address: "https://global-vault.example.com"
+  role_id: "global-role-id"
+  secret_id: "global-secret-id"
+  mount_path: "secret"
+
+tokens:
+  - label: "test-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+	cfg.ApplyDefaults()
+
+	// Account vault should override global for all fields
+	resolved := cfg.Account.Vault.Resolved(cfg.Vault)
+	assert.Equal(t, "https://account-vault.example.com", resolved.Address)
+	assert.Equal(t, "account-role-id", resolved.RoleID)
+	assert.Equal(t, "account-secret-id", resolved.SecretID)
+	assert.Equal(t, "custom-mount", resolved.MountPath)
+}
+
+func TestAccountVaultResolved_FallbackToGlobal(t *testing.T) {
+	global := VaultConfig{
+		Address:   "https://global.example.com",
+		RoleID:    "global-role",
+		SecretID:  "global-secret",
+		MountPath: "secret",
+	}
+
+	// Account vault with no overrides — should get all global values
+	acctVault := AccountVaultConfig{}
+	resolved := acctVault.Resolved(global)
+
+	assert.Equal(t, "https://global.example.com", resolved.Address)
+	assert.Equal(t, "global-role", resolved.RoleID)
+	assert.Equal(t, "global-secret", resolved.SecretID)
+	assert.Equal(t, "secret", resolved.MountPath)
+}
+
+func TestAccountVaultResolved_PartialOverride(t *testing.T) {
+	global := VaultConfig{
+		Address:   "https://global.example.com",
+		RoleID:    "global-role",
+		SecretID:  "global-secret",
+		MountPath: "secret",
+	}
+
+	// Account overrides only credentials, inherits address and mount_path
+	acctVault := AccountVaultConfig{
+		RoleID:   "account-role",
+		SecretID: "account-secret",
+	}
+	resolved := acctVault.Resolved(global)
+
+	assert.Equal(t, "https://global.example.com", resolved.Address)
+	assert.Equal(t, "account-role", resolved.RoleID)
+	assert.Equal(t, "account-secret", resolved.SecretID)
+	assert.Equal(t, "secret", resolved.MountPath)
+}
+
+func TestParseConfigNoAccountToken_EnvVarFallback(t *testing.T) {
+	yamlContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "test-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path"
+`
+
+	cfg, err := Parse([]byte(yamlContent))
+	require.NoError(t, err)
+	cfg.ApplyDefaults()
+
+	assert.Nil(t, cfg.Account.Token)
+	err = cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestValidateConfig_MissingAccountLabel(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+		},
+		Vault:  VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account label is required")
+}
+
+func TestValidateConfig_VaultCredentialsOptionalInConfig(t *testing.T) {
+	// role_id and secret_id are resolved at runtime (config or env var),
+	// so config validation should pass without them
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{}, // No credentials
+		},
+		Vault:  VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestValidateConfig_MissingVaultAddress(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+		},
+		Vault:  VaultConfig{}, // No address
+		Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vault address is required")
+}
+
+func TestValidateConfig_VaultAddressFromAccountOverride(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{
+				RoleID:   "r",
+				SecretID: "s",
+				Address:  "https://account-vault.example.com", // Override
+			},
+		},
+		Vault:  VaultConfig{}, // No global address — account override should suffice
+		Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
+	}
+
+	cfg.ApplyDefaults()
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestValidateConfig_ManagedTokenRequiresStorage(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+			Token: &AccountTokenConfig{
+				Label: "latr-main", Validity: "180d", Scopes: "*",
+			},
+		},
+		Vault: VaultConfig{Address: "https://vault.example.com"},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "managed token")
+	assert.Contains(t, err.Error(), "requires storage")
+}
+
+func TestValidateConfig_InvalidAccountTokenValidity(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+			Token: &AccountTokenConfig{
+				Storage: []StorageConfig{{Type: "vault", Path: "p"}},
+				Label:   "latr-main", Validity: "7mo", Scopes: "*",
+			},
+		},
+		Vault: VaultConfig{Address: "https://vault.example.com"},
 	}
 
 	err := cfg.Validate()
@@ -133,136 +463,94 @@ func TestValidateConfig_ValidityPeriodTooLong(t *testing.T) {
 	assert.Contains(t, err.Error(), "validity period must be <= 6 months")
 }
 
-func TestValidateConfig_ValidityPeriodExactly6Months(t *testing.T) {
+func TestValidateConfig_StorageMissingPath(t *testing.T) {
 	cfg := &Config{
-		Vault: VaultConfig{
-			Address:   "https://vault.example.com",
-			RoleID:    "test-role-id",
-			SecretID:  "test-secret-id",
-			MountPath: "secret",
-		},
-		Tokens: []TokenConfig{
-			{
-				Label:    "test-token",
-				Team:     "platform-team",
-				Validity: "180d", // Exactly 6 months
-				Scopes:   "*",
-				Storage: []StorageConfig{
-					{Type: "vault", Path: "secret/data/linode/tokens/test"},
-				},
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+			Token: &AccountTokenConfig{
+				Storage: []StorageConfig{{Type: "vault", Path: ""}},
 			},
 		},
+		Vault:  VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
 	}
 
 	err := cfg.Validate()
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path is required")
+}
+
+func TestValidateConfig_AccountTokenStorageKeyInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"slash", "bad/key"},
+		{"dotdot", "bad..key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Account: AccountConfig{
+					Label: "production",
+					Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+					Token: &AccountTokenConfig{
+						Storage: []StorageConfig{{Type: "vault", Path: "secrets/token", Key: tt.key}},
+					},
+				},
+				Vault:  VaultConfig{Address: "https://vault.example.com"},
+				Tokens: []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
+			}
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "key must not contain")
+		})
+	}
+}
+
+func TestValidateConfig_NoTokensAtAll(t *testing.T) {
+	cfg := &Config{
+		Account: AccountConfig{
+			Label: "production",
+			Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+		},
+		Vault:  VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one token must be configured")
 }
 
 func TestValidateConfig_MissingRequiredFields(t *testing.T) {
+	acct := AccountConfig{
+		Label: "production",
+		Vault: AccountVaultConfig{RoleID: "r", SecretID: "s"},
+	}
+
 	tests := []struct {
 		name   string
 		config *Config
 		errMsg string
 	}{
 		{
-			name: "missing vault address",
-			config: &Config{
-				Vault: VaultConfig{
-					RoleID:    "test-role-id",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
-			},
-			errMsg: "vault address is required",
-		},
-		{
-			name: "missing vault role_id",
-			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
-			},
-			errMsg: "vault role_id is required",
-		},
-		{
-			name: "missing vault secret_id",
-			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					RoleID:    "test-role-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
-			},
-			errMsg: "vault secret_id is required",
-		},
-		{
 			name: "missing token label",
 			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					RoleID:    "test-role-id",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Team: "team", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
+				Account: acct,
+				Vault:   VaultConfig{Address: "https://vault.example.com"},
+				Tokens:  []TokenConfig{{Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "p"}}}},
 			},
 			errMsg: "token label is required",
 		},
 		{
-			name: "missing token validity",
+			name: "missing token storage",
 			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					RoleID:    "test-role-id",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
-			},
-			errMsg: "token validity is required",
-		},
-		{
-			name: "missing token scopes",
-			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					RoleID:    "test-role-id",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Validity: "90d", Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
-				},
-			},
-			errMsg: "token scopes is required",
-		},
-		{
-			name: "no storage configured",
-			config: &Config{
-				Vault: VaultConfig{
-					Address:   "https://vault.example.com",
-					RoleID:    "test-role-id",
-					SecretID:  "test-secret-id",
-					MountPath: "secret",
-				},
-				Tokens: []TokenConfig{
-					{Label: "test", Team: "team", Validity: "90d", Scopes: "*", Storage: []StorageConfig{}},
-				},
+				Account: acct,
+				Vault:   VaultConfig{Address: "https://vault.example.com"},
+				Tokens:  []TokenConfig{{Label: "t", Validity: "90d", Scopes: "*", Storage: []StorageConfig{}}},
 			},
 			errMsg: "at least one storage backend is required",
 		},
@@ -275,6 +563,35 @@ func TestValidateConfig_MissingRequiredFields(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
+}
+
+func TestValidateConfig_ValidityPeriodTooLong(t *testing.T) {
+	cfg := &Config{
+		Account: testAccount(),
+		Vault:   VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{
+			{Label: "test-token", Validity: "7mo", Scopes: "*",
+				Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
+		},
+	}
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validity period must be <= 6 months")
+}
+
+func TestValidateConfig_ValidityPeriodExactly6Months(t *testing.T) {
+	cfg := &Config{
+		Account: testAccount(),
+		Vault:   VaultConfig{Address: "https://vault.example.com"},
+		Tokens: []TokenConfig{
+			{Label: "test-token", Validity: "180d", Scopes: "*",
+				Storage: []StorageConfig{{Type: "vault", Path: "path"}}},
+		},
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
 }
 
 func TestParseValidityDuration(t *testing.T) {
@@ -308,10 +625,14 @@ func TestParseValidityDuration(t *testing.T) {
 
 func TestTokenConfigOverrideThreshold(t *testing.T) {
 	yamlContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
 
 rotation:
   threshold_percent: 10
@@ -324,84 +645,49 @@ tokens:
     rotation_threshold: 15
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	cfg, err := Parse([]byte(yamlContent))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
 
 	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
 	assert.Equal(t, 15, cfg.Tokens[0].RotationThreshold)
 }
 
 func TestParseConfigWithEnvVarSubstitution(t *testing.T) {
-	// Set environment variables for testing
 	os.Setenv("TEST_VAULT_ADDRESS", "https://vault-from-env.example.com")
 	os.Setenv("TEST_VAULT_ROLE_ID", "role-id-from-env")
 	os.Setenv("TEST_VAULT_SECRET_ID", "secret-id-from-env")
-	os.Setenv("TEST_OTEL_ENDPOINT", "otel-from-env:4317")
 	defer func() {
 		os.Unsetenv("TEST_VAULT_ADDRESS")
 		os.Unsetenv("TEST_VAULT_ROLE_ID")
 		os.Unsetenv("TEST_VAULT_SECRET_ID")
-		os.Unsetenv("TEST_OTEL_ENDPOINT")
 	}()
 
 	yamlContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "${TEST_VAULT_ROLE_ID}"
+    secret_id: "${TEST_VAULT_SECRET_ID}"
+
 vault:
   address: "${TEST_VAULT_ADDRESS}"
-  role_id: "${TEST_VAULT_ROLE_ID}"
-  secret_id: "${TEST_VAULT_SECRET_ID}"
-  mount_path: "secret"
-
-observability:
-  otel_endpoint: "${TEST_OTEL_ENDPOINT}"
-  log_level: "info"
 
 tokens:
   - label: "test-token"
-    team: "platform-team"
     validity: "90d"
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	cfg, err := Parse([]byte(yamlContent))
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
 
-	// Verify environment variables were substituted
 	assert.Equal(t, "https://vault-from-env.example.com", cfg.Vault.Address)
-	assert.Equal(t, "role-id-from-env", cfg.Vault.RoleID)
-	assert.Equal(t, "secret-id-from-env", cfg.Vault.SecretID)
-	assert.Equal(t, "otel-from-env:4317", cfg.Observability.OTelEndpoint)
-}
-
-func TestParseConfigWithMissingEnvVar(t *testing.T) {
-	yamlContent := `
-vault:
-  address: "${MISSING_VAULT_ADDRESS}"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
-
-tokens:
-  - label: "test-token"
-    team: "platform-team"
-    validity: "90d"
-    scopes: "*"
-    storage:
-      - type: "vault"
-        path: "secret/data/linode/tokens/test"
-`
-
-	cfg, err := Parse([]byte(yamlContent))
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	// When env var is missing, viper leaves the literal string as-is
-	// This is expected behavior - validation will catch empty required fields
-	assert.Equal(t, "", cfg.Vault.Address)
+	assert.Equal(t, "role-id-from-env", cfg.Account.Vault.RoleID)
+	assert.Equal(t, "secret-id-from-env", cfg.Account.Vault.SecretID)
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -12,20 +12,21 @@ import (
 // TestLoadConfigFileWithEnvVars verifies that environment variables are properly
 // expanded when loading a config file, simulating the e2e test scenario
 func TestLoadConfigFileWithEnvVars(t *testing.T) {
-	// Create a temporary config file with env var references
-	// This simulates what the e2e tests do
-	configContent := `daemon:
+	configContent := `account:
+  label: "production"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+daemon:
   mode: "one-shot"
   dry_run: true
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -41,13 +42,11 @@ tokens:
         path: "e2e/test-dryrun"
 `
 
-	// Write config file to tmp
 	tmpFile := filepath.Join(os.TempDir(), "test-latr-config.yaml")
 	err := os.WriteFile(tmpFile, []byte(configContent), 0644)
 	require.NoError(t, err)
 	defer os.Remove(tmpFile)
 
-	// Set environment variables (simulating what runLatr() does in e2e tests)
 	os.Setenv("VAULT_ROLE_ID", "test-role-id-123")
 	os.Setenv("VAULT_SECRET_ID", "test-secret-id-456")
 	defer func() {
@@ -55,14 +54,12 @@ tokens:
 		os.Unsetenv("VAULT_SECRET_ID")
 	}()
 
-	// Load the config file (this calls os.Expand internally)
 	cfg, err := Load(tmpFile)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Verify environment variables were expanded correctly
-	assert.Equal(t, "test-role-id-123", cfg.Vault.RoleID, "VAULT_ROLE_ID should be expanded")
-	assert.Equal(t, "test-secret-id-456", cfg.Vault.SecretID, "VAULT_SECRET_ID should be expanded")
+	assert.Equal(t, "test-role-id-123", cfg.Account.Vault.RoleID, "VAULT_ROLE_ID should be expanded")
+	assert.Equal(t, "test-secret-id-456", cfg.Account.Vault.SecretID, "VAULT_SECRET_ID should be expanded")
 	assert.Equal(t, "http://localhost:8200", cfg.Vault.Address)
 	assert.Equal(t, "one-shot", cfg.Daemon.Mode)
 	assert.True(t, cfg.Daemon.DryRun)
@@ -71,10 +68,14 @@ tokens:
 // TestLoadConfigFileWithComplexEnvVarValues verifies that env vars with special
 // characters are handled correctly
 func TestLoadConfigFileWithComplexEnvVarValues(t *testing.T) {
-	configContent := `vault:
+	configContent := `account:
+  label: "production"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 tokens:
@@ -92,11 +93,10 @@ tokens:
 	require.NoError(t, err)
 	defer os.Remove(tmpFile)
 
-	// Test with values that contain hyphens, underscores, and numbers
 	testCases := []struct {
-		name      string
-		roleID    string
-		secretID  string
+		name     string
+		roleID   string
+		secretID string
 	}{
 		{
 			name:     "Simple alphanumeric",
@@ -133,8 +133,8 @@ tokens:
 			require.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			assert.Equal(t, tc.roleID, cfg.Vault.RoleID)
-			assert.Equal(t, tc.secretID, cfg.Vault.SecretID)
+			assert.Equal(t, tc.roleID, cfg.Account.Vault.RoleID)
+			assert.Equal(t, tc.secretID, cfg.Account.Vault.SecretID)
 		})
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -21,114 +21,127 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
-// LoadGlob loads and merges multiple configuration files matching a glob pattern
-func LoadGlob(pattern string) (*Config, error) {
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, fmt.Errorf("failed to glob pattern %s: %w", pattern, err)
+// LoadAll loads one or more configuration files matching a path or glob pattern.
+// Each file is loaded independently — accounts are not merged across files.
+func LoadAll(pathOrPattern string) ([]*Config, error) {
+	var paths []string
+
+	if containsGlobChar(pathOrPattern) {
+		matches, err := filepath.Glob(pathOrPattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob pattern %s: %w", pathOrPattern, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no config files found matching pattern: %s", pathOrPattern)
+		}
+		paths = matches
+	} else {
+		paths = []string{pathOrPattern}
 	}
 
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no config files found matching pattern: %s", pattern)
-	}
-
-	var merged *Config
-	for _, path := range matches {
+	configs := make([]*Config, 0, len(paths))
+	for _, path := range paths {
 		cfg, err := Load(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config file %s: %w", path, err)
 		}
-
-		if merged == nil {
-			merged = cfg
-		} else {
-			merged = MergeConfigs(merged, cfg)
-		}
+		configs = append(configs, cfg)
 	}
 
-	return merged, nil
+	return configs, nil
 }
 
-// MergeConfigs merges two configurations, with the second config overriding the first
-// for non-empty values. Tokens are appended rather than replaced.
-func MergeConfigs(base, override *Config) *Config {
-	merged := &Config{}
-
-	// Merge Daemon config
-	merged.Daemon = base.Daemon
-	if override.Daemon.Mode != "" {
-		merged.Daemon.Mode = override.Daemon.Mode
-	}
-	if override.Daemon.CheckInterval != "" {
-		merged.Daemon.CheckInterval = override.Daemon.CheckInterval
-	}
-	if override.Daemon.DryRun {
-		merged.Daemon.DryRun = override.Daemon.DryRun
-	}
-
-	// Merge Rotation config
-	merged.Rotation = base.Rotation
-	if override.Rotation.ThresholdPercent != 0 {
-		merged.Rotation.ThresholdPercent = override.Rotation.ThresholdPercent
-	}
-
-	// Merge Vault config
-	merged.Vault = base.Vault
-	if override.Vault.Address != "" {
-		merged.Vault.Address = override.Vault.Address
-	}
-	if override.Vault.RoleID != "" {
-		merged.Vault.RoleID = override.Vault.RoleID
-	}
-	if override.Vault.SecretID != "" {
-		merged.Vault.SecretID = override.Vault.SecretID
-	}
-	if override.Vault.MountPath != "" {
-		merged.Vault.MountPath = override.Vault.MountPath
-	}
-
-	// Merge Observability config
-	merged.Observability = base.Observability
-	if override.Observability.OTelEndpoint != "" {
-		merged.Observability.OTelEndpoint = override.Observability.OTelEndpoint
-	}
-	if override.Observability.LogLevel != "" {
-		merged.Observability.LogLevel = override.Observability.LogLevel
-	}
-
-	// Merge tokens (append, don't replace)
-	merged.Tokens = append([]TokenConfig{}, base.Tokens...)
-	merged.Tokens = append(merged.Tokens, override.Tokens...)
-
-	return merged
-}
-
-// LoadAndValidate loads a configuration file (or glob pattern), applies defaults,
-// and validates it
-func LoadAndValidate(pathOrPattern string) (*Config, error) {
-	var cfg *Config
-	var err error
-
-	// Check if it's a glob pattern (contains * or ?)
-	if containsGlobChar(pathOrPattern) {
-		cfg, err = LoadGlob(pathOrPattern)
-	} else {
-		cfg, err = Load(pathOrPattern)
-	}
-
+// LoadAndValidate loads configuration file(s), applies defaults, and validates.
+// Returns a slice of configs — one per file. The config marked global: true
+// (or the first file if none is marked) provides default settings that are
+// propagated to other configs.
+func LoadAndValidate(pathOrPattern string) ([]*Config, error) {
+	configs, err := LoadAll(pathOrPattern)
 	if err != nil {
 		return nil, err
 	}
 
-	// Apply defaults
-	cfg.ApplyDefaults()
-
-	// Validate
-	if err := cfg.Validate(); err != nil {
-		return nil, fmt.Errorf("config validation failed: %w", err)
+	// Find the global config (if any) and use it as the source for defaults.
+	// If no config is marked global, the first config serves as the default source.
+	var globalCfg *Config
+	for _, cfg := range configs {
+		if cfg.IsGlobal() {
+			if globalCfg != nil {
+				return nil, fmt.Errorf("multiple configs marked as global: true")
+			}
+			globalCfg = cfg
+		}
+	}
+	if globalCfg == nil {
+		globalCfg = configs[0]
 	}
 
-	return cfg, nil
+	globalCfg.ApplyDefaults()
+
+	for _, cfg := range configs {
+		if cfg != globalCfg {
+			propagateGlobals(globalCfg, cfg)
+			cfg.ApplyDefaults()
+		}
+	}
+
+	// Validate all configs
+	for i, cfg := range configs {
+		if err := cfg.Validate(); err != nil {
+			if len(configs) > 1 {
+				return nil, fmt.Errorf("config file %d: %w", i+1, err)
+			}
+			return nil, fmt.Errorf("config validation failed: %w", err)
+		}
+	}
+
+	// Validate account label uniqueness and ensure at least one account exists
+	seenLabels := make(map[string]int)
+	for i, cfg := range configs {
+		if cfg.Account.Label == "" {
+			continue
+		}
+		if prev, exists := seenLabels[cfg.Account.Label]; exists {
+			return nil, fmt.Errorf("duplicate account label %q in config files %d and %d", cfg.Account.Label, prev, i+1)
+		}
+		seenLabels[cfg.Account.Label] = i + 1
+	}
+	if len(seenLabels) == 0 {
+		return nil, fmt.Errorf("at least one config file must have an account block")
+	}
+
+	return configs, nil
+}
+
+// propagateGlobals copies global settings from the primary config to a
+// secondary config for any fields the secondary config doesn't set.
+func propagateGlobals(primary, secondary *Config) {
+	// Note: Daemon.DryRun is not propagated because a bool zero-value (false)
+	// is indistinguishable from "not set". Daemon settings are global-only.
+
+	// Rotation
+	if secondary.Rotation.ThresholdPercent == 0 {
+		secondary.Rotation.ThresholdPercent = primary.Rotation.ThresholdPercent
+	}
+
+	// Vault
+	if secondary.Vault.Address == "" {
+		secondary.Vault.Address = primary.Vault.Address
+	}
+	if secondary.Vault.RoleID == "" {
+		secondary.Vault.RoleID = primary.Vault.RoleID
+	}
+	if secondary.Vault.SecretID == "" {
+		secondary.Vault.SecretID = primary.Vault.SecretID
+	}
+	if secondary.Vault.MountPath == "" {
+		secondary.Vault.MountPath = primary.Vault.MountPath
+	}
+
+	// Note: Observability settings are NOT propagated because they are global-only.
+	// Telemetry/logging is initialized once from the primary config and applies
+	// to the entire process. Per-account observability overrides are ignored
+	// (with a warning logged in main.go).
 }
 
 // containsGlobChar checks if a path contains glob characters

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -56,9 +56,28 @@ func LoadAll(pathOrPattern string) ([]*Config, error) {
 // (or the first file if none is marked) provides default settings that are
 // propagated to other configs.
 func LoadAndValidate(pathOrPattern string) ([]*Config, error) {
-	configs, err := LoadAll(pathOrPattern)
-	if err != nil {
-		return nil, err
+	// Resolve paths so we can include filenames in error messages
+	var paths []string
+	if containsGlobChar(pathOrPattern) {
+		matches, err := filepath.Glob(pathOrPattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob pattern %s: %w", pathOrPattern, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no config files found matching pattern: %s", pathOrPattern)
+		}
+		paths = matches
+	} else {
+		paths = []string{pathOrPattern}
+	}
+
+	configs := make([]*Config, 0, len(paths))
+	for _, path := range paths {
+		cfg, err := Load(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config file %s: %w", path, err)
+		}
+		configs = append(configs, cfg)
 	}
 
 	// Find the global config (if any) and use it as the source for defaults.
@@ -89,7 +108,7 @@ func LoadAndValidate(pathOrPattern string) ([]*Config, error) {
 	for i, cfg := range configs {
 		if err := cfg.Validate(); err != nil {
 			if len(configs) > 1 {
-				return nil, fmt.Errorf("config file %d: %w", i+1, err)
+				return nil, fmt.Errorf("config file %s: %w", paths[i], err)
 			}
 			return nil, fmt.Errorf("config validation failed: %w", err)
 		}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -10,15 +10,18 @@ import (
 )
 
 func TestLoadSingleFile(t *testing.T) {
-	// Create a temporary config file
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
 	configContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
   mount_path: "secret"
 
 tokens:
@@ -28,20 +31,18 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	// Load the config
 	cfg, err := Load(configPath)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Verify loaded config
+	assert.Equal(t, "production", cfg.Account.Label)
 	assert.Equal(t, "https://vault.example.com", cfg.Vault.Address)
-	assert.Equal(t, "test-role-id", cfg.Vault.RoleID)
 	require.Len(t, cfg.Tokens, 1)
 	assert.Equal(t, "test-token", cfg.Tokens[0].Label)
 }
@@ -53,15 +54,16 @@ func TestLoadFileNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to read config file")
 }
 
-func TestLoadGlobPattern(t *testing.T) {
-	// Create temporary config files
+func TestLoadAllMultipleFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	config1 := `
+account:
+  label: "production"
+  team: "platform-team"
+
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
 
 tokens:
   - label: "token1"
@@ -70,10 +72,18 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/token1"
+        path: "linode/tokens/token1"
 `
 
 	config2 := `
+account:
+  label: "staging"
+  team: "platform-team"
+  vault:
+    role_id: "staging-role-id"
+    secret_id: "staging-secret-id"
+  api_url: "https://api.staging.example.com"
+
 tokens:
   - label: "token2"
     team: "team2"
@@ -81,7 +91,7 @@ tokens:
     scopes: "linodes:read_only"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/token2"
+        path: "linode/tokens/token2"
 `
 
 	err := os.WriteFile(filepath.Join(tmpDir, "config1.yaml"), []byte(config1), 0644)
@@ -89,109 +99,145 @@ tokens:
 	err = os.WriteFile(filepath.Join(tmpDir, "config2.yaml"), []byte(config2), 0644)
 	require.NoError(t, err)
 
-	// Load with glob pattern
 	pattern := filepath.Join(tmpDir, "*.yaml")
-	cfg, err := LoadGlob(pattern)
+	configs, err := LoadAll(pattern)
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
+	require.Len(t, configs, 2)
 
-	// Verify merged config
-	assert.Equal(t, "https://vault.example.com", cfg.Vault.Address)
-	require.Len(t, cfg.Tokens, 2)
+	// Each config should have its own account
+	labels := []string{configs[0].Account.Label, configs[1].Account.Label}
+	assert.Contains(t, labels, "production")
+	assert.Contains(t, labels, "staging")
 
-	// Tokens should be present
-	labels := []string{cfg.Tokens[0].Label, cfg.Tokens[1].Label}
-	assert.Contains(t, labels, "token1")
-	assert.Contains(t, labels, "token2")
+	// Tokens should NOT be merged
+	for _, cfg := range configs {
+		require.Len(t, cfg.Tokens, 1)
+	}
 }
 
-func TestLoadGlobNoMatches(t *testing.T) {
-	tmpDir := t.TempDir()
-	pattern := filepath.Join(tmpDir, "*.yaml")
-
-	cfg, err := LoadGlob(pattern)
-	require.Error(t, err)
-	assert.Nil(t, cfg)
-	assert.Contains(t, err.Error(), "no config files found")
-}
-
-func TestMergeConfigs(t *testing.T) {
-	config1 := &Config{
-		Vault: VaultConfig{
-			Address:   "https://vault.example.com",
-			RoleID:    "role-id",
-			SecretID:  "secret-id",
-			MountPath: "secret",
-		},
-		Daemon: DaemonConfig{
-			Mode:          "daemon",
-			CheckInterval: "30m",
-		},
-		Rotation: RotationConfig{
-			ThresholdPercent: 10,
-		},
-		Tokens: []TokenConfig{
-			{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path1"}}},
-		},
-	}
-
-	config2 := &Config{
-		Tokens: []TokenConfig{
-			{Label: "token2", Team: "team2", Validity: "180d", Scopes: "*", Storage: []StorageConfig{{Type: "vault", Path: "path2"}}},
-		},
-	}
-
-	merged := MergeConfigs(config1, config2)
-
-	// Vault config should come from config1
-	assert.Equal(t, "https://vault.example.com", merged.Vault.Address)
-	assert.Equal(t, "role-id", merged.Vault.RoleID)
-
-	// Daemon config should come from config1
-	assert.Equal(t, "daemon", merged.Daemon.Mode)
-
-	// Tokens should be merged
-	require.Len(t, merged.Tokens, 2)
-	labels := []string{merged.Tokens[0].Label, merged.Tokens[1].Label}
-	assert.Contains(t, labels, "token1")
-	assert.Contains(t, labels, "token2")
-}
-
-func TestMergeConfigsOverride(t *testing.T) {
-	config1 := &Config{
-		Vault: VaultConfig{
-			Address: "https://vault1.example.com",
-		},
-		Rotation: RotationConfig{
-			ThresholdPercent: 10,
-		},
-	}
-
-	config2 := &Config{
-		Vault: VaultConfig{
-			Address: "https://vault2.example.com",
-		},
-		Rotation: RotationConfig{
-			ThresholdPercent: 15,
-		},
-	}
-
-	merged := MergeConfigs(config1, config2)
-
-	// Second config should override first for non-empty values
-	assert.Equal(t, "https://vault2.example.com", merged.Vault.Address)
-	assert.Equal(t, 15, merged.Rotation.ThresholdPercent)
-}
-
-func TestLoadAndValidate(t *testing.T) {
+func TestLoadAllSingleFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
 	configContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
 vault:
   address: "https://vault.example.com"
-  role_id: "test-role-id"
-  secret_id: "test-secret-id"
+
+tokens:
+  - label: "test-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path"
+`
+
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	configs, err := LoadAll(configPath)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "production", configs[0].Account.Label)
+}
+
+func TestLoadAllNoMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	pattern := filepath.Join(tmpDir, "*.yaml")
+
+	configs, err := LoadAll(pattern)
+	require.Error(t, err)
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "no config files found")
+}
+
+func TestLoadAndValidateMultipleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config1 := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
+daemon:
+  mode: "daemon"
+  check_interval: "30m"
+
+rotation:
+  threshold_percent: 10
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "token1"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path1"
+`
+
+	config2 := `
+account:
+  label: "staging"
+  vault:
+    role_id: "staging-role-id"
+    secret_id: "staging-secret-id"
+  api_url: "https://api.staging.example.com"
+
+tokens:
+  - label: "token2"
+    validity: "180d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path2"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "config1.yaml"), []byte(config1), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "config2.yaml"), []byte(config2), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.NoError(t, err)
+	require.Len(t, configs, 2)
+
+	// Global settings should be propagated to second config
+	assert.Equal(t, "https://vault.example.com", configs[1].Vault.Address)
+	assert.Equal(t, "staging-role-id", configs[1].Account.Vault.RoleID)
+	assert.Equal(t, "daemon", configs[1].Daemon.Mode)
+	assert.Equal(t, 10, configs[1].Rotation.ThresholdPercent)
+
+	// Account-specific settings should remain independent
+	assert.Equal(t, "production", configs[0].Account.Label)
+	assert.Equal(t, "staging", configs[1].Account.Label)
+	assert.Equal(t, "https://api.staging.example.com", configs[1].Account.APIURL)
+}
+
+func TestLoadAndValidateSingleFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+account:
+  label: "production"
+  vault:
+    role_id: "test-role-id"
+    secret_id: "test-secret-id"
+
+vault:
+  address: "https://vault.example.com"
 
 tokens:
   - label: "test-token"
@@ -200,44 +246,265 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	// Load and validate
-	cfg, err := LoadAndValidate(configPath)
+	configs, err := LoadAndValidate(configPath)
 	require.NoError(t, err)
-	require.NotNil(t, cfg)
+	require.Len(t, configs, 1)
 
-	// Defaults should be applied
-	assert.Equal(t, "daemon", cfg.Daemon.Mode)
-	assert.Equal(t, "30m", cfg.Daemon.CheckInterval)
-	assert.Equal(t, 10, cfg.Rotation.ThresholdPercent)
+	assert.Equal(t, "daemon", configs[0].Daemon.Mode)
+	assert.Equal(t, "30m", configs[0].Daemon.CheckInterval)
+	assert.Equal(t, 10, configs[0].Rotation.ThresholdPercent)
+	assert.Equal(t, "", configs[0].Account.APIURL)
+}
+
+func TestLoadAndValidateGlobalsOnlyPlusAccounts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	globals := `
+global: true
+
+daemon:
+  mode: "daemon"
+  check_interval: "30m"
+
+rotation:
+  threshold_percent: 10
+
+vault:
+  address: "https://vault.example.com"
+  role_id: "global-role-id"
+  secret_id: "global-secret-id"
+
+observability:
+  log_level: "info"
+`
+
+	account := `
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+
+tokens:
+  - label: "my-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "tokens/my-token"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "globals.yaml"), []byte(globals), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "account.yaml"), []byte(account), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.NoError(t, err)
+
+	// Should have 2 configs — global + account
+	require.Len(t, configs, 2)
+
+	// Find the global config
+	var globalIdx, acctIdx int
+	for i, cfg := range configs {
+		if cfg.IsGlobal() {
+			globalIdx = i
+		} else {
+			acctIdx = i
+		}
+	}
+	assert.True(t, configs[globalIdx].IsGlobal())
+
+	// Account config should have inherited global settings
+	acct := configs[acctIdx]
+	assert.Equal(t, "lcid-1234", acct.Account.Label)
+	assert.Equal(t, "https://vault.example.com", acct.Vault.Address)
+	assert.Equal(t, "global-role-id", acct.Vault.RoleID)
+	assert.Equal(t, "daemon", acct.Daemon.Mode)
+	assert.Equal(t, 10, acct.Rotation.ThresholdPercent)
+}
+
+func TestLoadAndValidateOnlyGlobalConfig_Fails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	globals := `
+global: true
+
+daemon:
+  mode: "daemon"
+
+vault:
+  address: "https://vault.example.com"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "globals.yaml"), []byte(globals), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.Error(t, err)
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "at least one config file must have an account block")
+}
+
+func TestLoadAndValidateGlobalWithAccount(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	combined := `
+global: true
+
+account:
+  label: "lcid-1234"
+  team: "platform-team"
+
+daemon:
+  mode: "one-shot"
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "my-token"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "tokens/my-token"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(combined), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+
+	cfg := configs[0]
+	assert.True(t, cfg.IsGlobal())
+	assert.Equal(t, "lcid-1234", cfg.Account.Label)
+	assert.Len(t, cfg.Tokens, 1)
+	assert.Equal(t, "one-shot", cfg.Daemon.Mode)
+}
+
+func TestLoadAndValidateMultipleGlobals_Fails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	globals1 := `
+global: true
+vault:
+  address: "https://vault1.example.com"
+`
+	globals2 := `
+global: true
+vault:
+  address: "https://vault2.example.com"
+`
+	account := `
+account:
+  label: "test"
+tokens:
+  - label: "t"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "p"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "a-globals1.yaml"), []byte(globals1), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "b-globals2.yaml"), []byte(globals2), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "c-account.yaml"), []byte(account), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.Error(t, err)
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "multiple configs marked as global")
+}
+
+func TestLoadAndValidateDuplicateAccountLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config1 := `
+account:
+  label: "same-label"
+  vault:
+    role_id: "r1"
+    secret_id: "s1"
+
+vault:
+  address: "https://vault.example.com"
+
+tokens:
+  - label: "token1"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path1"
+`
+
+	config2 := `
+account:
+  label: "same-label"
+  vault:
+    role_id: "r2"
+    secret_id: "s2"
+
+tokens:
+  - label: "token2"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path2"
+`
+
+	err := os.WriteFile(filepath.Join(tmpDir, "config1.yaml"), []byte(config1), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "config2.yaml"), []byte(config2), 0644)
+	require.NoError(t, err)
+
+	pattern := filepath.Join(tmpDir, "*.yaml")
+	configs, err := LoadAndValidate(pattern)
+	require.Error(t, err)
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "duplicate account label")
+	assert.Contains(t, err.Error(), "same-label")
 }
 
 func TestLoadAndValidateInvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
-	// Missing required vault fields
 	configContent := `
+vault:
+  address: "https://vault.example.com"
+
 tokens:
   - label: "test-token"
-    team: "platform-team"
     validity: "90d"
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/linode/tokens/test"
+        path: "linode/tokens/test"
 `
 
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	cfg, err := LoadAndValidate(configPath)
+	configs, err := LoadAndValidate(configPath)
 	require.Error(t, err)
-	assert.Nil(t, cfg)
-	assert.Contains(t, err.Error(), "vault address is required")
+	assert.Nil(t, configs)
+	assert.Contains(t, err.Error(), "account label is required")
 }

--- a/internal/linode/client.go
+++ b/internal/linode/client.go
@@ -3,8 +3,6 @@ package linode
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"os"
 	"time"
 
 	"github.com/linode/linodego"
@@ -18,17 +16,17 @@ type Client struct {
 	token  string
 }
 
-// NewClient creates a new Linode API client
-func NewClient(token string) *Client {
+// NewClient creates a new Linode API client.
+// The apiURL parameter sets the Linode API base URL. If empty, the linodego
+// default (https://api.linode.com) is used.
+func NewClient(token, apiURL string) *Client {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauth2Client := oauth2.NewClient(context.Background(), tokenSource)
 
 	linodeClient := linodego.NewClient(oauth2Client)
 
-	// Support base URL override for testing
-	baseURL := os.Getenv("LINODE_API_URL")
-	if baseURL != "" {
-		linodeClient.SetBaseURL(baseURL)
+	if apiURL != "" {
+		linodeClient.SetBaseURL(apiURL)
 	}
 
 	return &Client{
@@ -50,42 +48,23 @@ func (c *Client) CreateToken(ctx context.Context, label, scopes string, expiry t
 		return nil, fmt.Errorf("failed to create token: %w", err)
 	}
 
-	return &models.Token{
-		ID:        token.ID,
-		Label:     token.Label,
-		Token:     token.Token,
-		CreatedAt: *token.Created,
-		ExpiresAt: *token.Expiry,
-		Scopes:    token.Scopes,
-		Validity:  time.Until(*token.Expiry),
-	}, nil
-}
-
-// GetToken retrieves a token by ID
-func (c *Client) GetToken(ctx context.Context, tokenID int) (*models.Token, error) {
-	token, err := c.client.GetToken(ctx, tokenID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get token: %w", err)
-	}
-
 	created := time.Now()
 	if token.Created != nil {
 		created = *token.Created
 	}
-
-	expiry := time.Now().Add(90 * 24 * time.Hour)
+	tokenExpiry := expiry
 	if token.Expiry != nil {
-		expiry = *token.Expiry
+		tokenExpiry = *token.Expiry
 	}
 
 	return &models.Token{
 		ID:        token.ID,
 		Label:     token.Label,
-		Token:     "", // The API doesn't return the token value for existing tokens
+		Token:     token.Token,
 		CreatedAt: created,
-		ExpiresAt: expiry,
+		ExpiresAt: tokenExpiry,
 		Scopes:    token.Scopes,
-		Validity:  expiry.Sub(created),
+		Validity:  tokenExpiry.Sub(created),
 	}, nil
 }
 
@@ -130,37 +109,4 @@ func (c *Client) FindTokenByLabel(ctx context.Context, label string) ([]*models.
 	}
 
 	return result, nil
-}
-
-// UpdateToken updates a token's expiry (if supported by the API)
-// Note: Linode API may not support updating token expiry, so we may need to create a new one
-func (c *Client) UpdateToken(ctx context.Context, tokenID int, expiry time.Time) error {
-	updateOpts := linodego.TokenUpdateOptions{
-		Label: "", // Keep existing label
-	}
-
-	_, err := c.client.UpdateToken(ctx, tokenID, updateOpts)
-	if err != nil {
-		return fmt.Errorf("failed to update token: %w", err)
-	}
-	return nil
-}
-
-// IsNotFoundError checks if an error is a 404 not found error
-func IsNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	if apiErr, ok := err.(*linodego.Error); ok {
-		return apiErr.Code == http.StatusNotFound
-	}
-
-	return false
-}
-
-// ParseScopes parses and returns the scopes string
-// This is a simple pass-through for now, but could be enhanced to validate scopes
-func ParseScopes(scopes string) string {
-	return scopes
 }

--- a/internal/linode/client_test.go
+++ b/internal/linode/client_test.go
@@ -1,62 +1,14 @@
 package linode
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewClient(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient("test-token", "")
 	require.NotNil(t, client)
 	assert.Equal(t, "test-token", client.token)
-}
-
-func TestCreateToken(t *testing.T) {
-	// This test will use a mock server to avoid real API calls
-	// For now, we'll write a test that verifies the method signature and structure
-	client := NewClient("test-token")
-	require.NotNil(t, client)
-
-	ctx := context.Background()
-	expiry := time.Now().Add(90 * 24 * time.Hour)
-
-	// Note: This will be tested with integration tests or mocks
-	// For unit tests, we'll verify the client can be created
-	_ = ctx
-	_ = expiry
-}
-
-func TestParseTokenScopes(t *testing.T) {
-	tests := []struct {
-		name     string
-		scopes   string
-		expected string
-	}{
-		{
-			name:     "wildcard scopes",
-			scopes:   "*",
-			expected: "*",
-		},
-		{
-			name:     "specific scopes",
-			scopes:   "linodes:read_only,domains:read_only",
-			expected: "linodes:read_only,domains:read_only",
-		},
-		{
-			name:     "single scope",
-			scopes:   "linodes:read_write",
-			expected: "linodes:read_write",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ParseScopes(tt.scopes)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/internal/rotation/engine.go
+++ b/internal/rotation/engine.go
@@ -21,8 +21,7 @@ type LinodeClient interface {
 
 // VaultClient defines the interface for Vault operations
 type VaultClient interface {
-	WriteToken(ctx context.Context, path, token string) error
-	ReadToken(ctx context.Context, path string) (string, error)
+	WriteToken(ctx context.Context, path, key, token string) error
 	WriteTokenState(ctx context.Context, path string, state *models.TokenState) error
 	ReadTokenState(ctx context.Context, path string) (*models.TokenState, error)
 }
@@ -32,6 +31,18 @@ type Engine struct {
 	linodeClient LinodeClient
 	vaultClient  VaultClient
 	dryRun       bool
+}
+
+// statePath returns the Vault path used for token state tracking (custom_metadata).
+// When a non-default storage key is used, the key is appended to the path to
+// avoid metadata collisions between tokens that share a Vault path but use
+// different keys (e.g., account.token using account.label as key vs a regular
+// token using the default "token" key on the same path).
+func statePath(storage config.StorageConfig) string {
+	if storage.Key == "" || storage.Key == "token" {
+		return storage.Path
+	}
+	return storage.Path + "/" + storage.Key
 }
 
 // NewEngine creates a new rotation engine
@@ -146,7 +157,7 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 	}
 
 	// Read existing state (if any)
-	storagePath := tokenConfig.Storage[0].Path
+	storagePath := statePath(tokenConfig.Storage[0])
 	existingState, err := e.vaultClient.ReadTokenState(ctx, storagePath)
 	if err != nil {
 		span.RecordError(err)
@@ -234,7 +245,7 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 	}
 
 	// Read existing state
-	storagePath := tokenConfig.Storage[0].Path
+	storagePath := statePath(tokenConfig.Storage[0])
 	existingState, err := e.vaultClient.ReadTokenState(ctx, storagePath)
 	if err != nil {
 		span.RecordError(err)
@@ -301,8 +312,9 @@ func (e *Engine) storeTokenInBackends(ctx context.Context, storageConfigs []conf
 	logger := observability.GetLogger()
 
 	for _, storage := range storageConfigs {
-		if storage.Type == "vault" {
-			if err := e.vaultClient.WriteToken(ctx, storage.Path, token); err != nil {
+		switch storage.Type {
+		case "vault":
+			if err := e.vaultClient.WriteToken(ctx, storage.Path, storage.Key, token); err != nil {
 				return err
 			}
 			attrs := append([]any{
@@ -310,6 +322,8 @@ func (e *Engine) storeTokenInBackends(ctx context.Context, storageConfigs []conf
 				slog.String("vault_path", storage.Path),
 			}, observability.TraceAttrs(ctx)...)
 			logger.InfoContext(ctx, "Stored token in Vault", attrs...)
+		default:
+			return fmt.Errorf("unsupported storage type: %s", storage.Type)
 		}
 	}
 	return nil

--- a/internal/rotation/engine_test.go
+++ b/internal/rotation/engine_test.go
@@ -39,14 +39,9 @@ type MockVaultClient struct {
 	mock.Mock
 }
 
-func (m *MockVaultClient) WriteToken(ctx context.Context, path, token string) error {
-	args := m.Called(ctx, path, token)
+func (m *MockVaultClient) WriteToken(ctx context.Context, path, key, token string) error {
+	args := m.Called(ctx, path, key, token)
 	return args.Error(0)
-}
-
-func (m *MockVaultClient) ReadToken(ctx context.Context, path string) (string, error) {
-	args := m.Called(ctx, path)
-	return args.String(0), args.Error(1)
 }
 
 func (m *MockVaultClient) WriteTokenState(ctx context.Context, path string, state *models.TokenState) error {
@@ -72,7 +67,7 @@ func TestEngine_ProcessToken_NewToken(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/new-token"},
+			{Type: "vault", Path: "test/new-token"},
 		},
 	}
 
@@ -92,9 +87,9 @@ func TestEngine_ProcessToken_NewToken(t *testing.T) {
 	mockLinode.On("CreateToken", mock.Anything, "new-token", "*", mock.Anything).Return(createdToken, nil)
 
 	// Vault operations
-	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/new-token").Return(nil, nil)
-	mockVault.On("WriteToken", mock.Anything, "secret/data/test/new-token", "new-secret-token").Return(nil)
-	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/new-token", mock.Anything).Return(nil)
+	mockVault.On("ReadTokenState", mock.Anything, "test/new-token").Return(nil, nil)
+	mockVault.On("WriteToken", mock.Anything, "test/new-token", "", "new-secret-token").Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "test/new-token", mock.Anything).Return(nil)
 
 	engine := &Engine{
 		linodeClient: mockLinode,
@@ -120,7 +115,7 @@ func TestEngine_ProcessToken_ExistingToken_NoRotationNeeded(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/existing-token"},
+			{Type: "vault", Path: "test/existing-token"},
 		},
 	}
 
@@ -161,7 +156,7 @@ func TestEngine_ProcessToken_ExistingToken_NeedsRotation(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/existing-token"},
+			{Type: "vault", Path: "test/existing-token"},
 		},
 	}
 
@@ -195,9 +190,9 @@ func TestEngine_ProcessToken_ExistingToken_NeedsRotation(t *testing.T) {
 	mockLinode.On("FindTokenByLabel", mock.Anything, "existing-token").Return(existingToken, nil)
 	mockLinode.On("CreateToken", mock.Anything, "existing-token", "*", mock.Anything).Return(newToken, nil)
 
-	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/existing-token").Return(existingState, nil)
-	mockVault.On("WriteToken", mock.Anything, "secret/data/test/existing-token", "new-rotated-token").Return(nil)
-	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/existing-token", mock.MatchedBy(func(state *models.TokenState) bool {
+	mockVault.On("ReadTokenState", mock.Anything, "test/existing-token").Return(existingState, nil)
+	mockVault.On("WriteToken", mock.Anything, "test/existing-token", "", "new-rotated-token").Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "test/existing-token", mock.MatchedBy(func(state *models.TokenState) bool {
 		return state.CurrentLinodeID == 456 &&
 			state.PreviousLinodeID == 123 &&
 			state.RotationCount == 1
@@ -227,7 +222,7 @@ func TestEngine_ProcessToken_DryRunMode(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/dry-run-token"},
+			{Type: "vault", Path: "test/dry-run-token"},
 		},
 	}
 
@@ -260,7 +255,7 @@ func TestEngine_ProcessToken_LinodeCreateFails(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/new-token"},
+			{Type: "vault", Path: "test/new-token"},
 		},
 	}
 
@@ -268,7 +263,7 @@ func TestEngine_ProcessToken_LinodeCreateFails(t *testing.T) {
 	mockLinode.On("FindTokenByLabel", mock.Anything, "new-token").Return(nil, nil)
 	mockLinode.On("CreateToken", mock.Anything, "new-token", "*", mock.Anything).Return(nil, errors.New("API error"))
 
-	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/new-token").Return(nil, nil)
+	mockVault.On("ReadTokenState", mock.Anything, "test/new-token").Return(nil, nil)
 
 	engine := &Engine{
 		linodeClient: mockLinode,
@@ -296,7 +291,7 @@ func TestEngine_ProcessToken_VaultWriteFails_StateTracked(t *testing.T) {
 		Validity: "90d",
 		Scopes:   "*",
 		Storage: []config.StorageConfig{
-			{Type: "vault", Path: "secret/data/test/new-token"},
+			{Type: "vault", Path: "test/new-token"},
 		},
 	}
 
@@ -314,10 +309,10 @@ func TestEngine_ProcessToken_VaultWriteFails_StateTracked(t *testing.T) {
 	mockLinode.On("FindTokenByLabel", mock.Anything, "new-token").Return(nil, nil)
 	mockLinode.On("CreateToken", mock.Anything, "new-token", "*", mock.Anything).Return(createdToken, nil)
 
-	mockVault.On("ReadTokenState", mock.Anything, "secret/data/test/new-token").Return(nil, nil)
-	mockVault.On("WriteToken", mock.Anything, "secret/data/test/new-token", "new-secret-token").Return(errors.New("vault error"))
+	mockVault.On("ReadTokenState", mock.Anything, "test/new-token").Return(nil, nil)
+	mockVault.On("WriteToken", mock.Anything, "test/new-token", "", "new-secret-token").Return(errors.New("vault error"))
 	// State should still be written to track that we need to retry Vault write
-	mockVault.On("WriteTokenState", mock.Anything, "secret/data/test/new-token", mock.Anything).Return(nil)
+	mockVault.On("WriteTokenState", mock.Anything, "test/new-token", mock.Anything).Return(nil)
 
 	engine := &Engine{
 		linodeClient: mockLinode,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -17,23 +17,31 @@ type Engine interface {
 	ProcessToken(ctx context.Context, tokenConfig config.TokenConfig, thresholdPercent int) error
 }
 
+// AccountEntry represents an account with its associated engine and tokens
+type AccountEntry struct {
+	Account  config.AccountConfig
+	Tokens   []config.TokenConfig
+	Engine   Engine
+	Rotation config.RotationConfig
+}
+
 // Scheduler manages the execution schedule for token rotation
 type Scheduler struct {
-	config *config.Config
-	engine Engine
+	daemon   config.DaemonConfig
+	accounts []AccountEntry
 }
 
 // NewScheduler creates a new scheduler
-func NewScheduler(cfg *config.Config, engine Engine) *Scheduler {
+func NewScheduler(daemon config.DaemonConfig, accounts []AccountEntry) *Scheduler {
 	return &Scheduler{
-		config: cfg,
-		engine: engine,
+		daemon:   daemon,
+		accounts: accounts,
 	}
 }
 
 // Run starts the scheduler based on the configured mode
 func (s *Scheduler) Run(ctx context.Context) error {
-	if s.config.Daemon.Mode == "one-shot" {
+	if s.daemon.Mode == "one-shot" {
 		return s.runOnce(ctx)
 	}
 	return s.runDaemon(ctx)
@@ -50,10 +58,10 @@ func (s *Scheduler) runOnce(ctx context.Context) error {
 // runDaemon runs the rotation cycle at regular intervals
 func (s *Scheduler) runDaemon(ctx context.Context) error {
 	logger := observability.GetLogger()
-	attrs := append([]any{slog.String("check_interval", s.config.Daemon.CheckInterval)}, observability.TraceAttrs(ctx)...)
+	attrs := append([]any{slog.String("check_interval", s.daemon.CheckInterval)}, observability.TraceAttrs(ctx)...)
 	logger.InfoContext(ctx, "Running in daemon mode", attrs...)
 
-	interval, err := time.ParseDuration(s.config.Daemon.CheckInterval)
+	interval, err := time.ParseDuration(s.daemon.CheckInterval)
 	if err != nil {
 		return fmt.Errorf("invalid check interval: %w", err)
 	}
@@ -84,7 +92,7 @@ func (s *Scheduler) runDaemon(ctx context.Context) error {
 	}
 }
 
-// executeCycle processes all configured tokens
+// executeCycle processes all tokens across all accounts
 func (s *Scheduler) executeCycle(ctx context.Context) error {
 	logger := observability.GetLogger()
 
@@ -93,37 +101,72 @@ func (s *Scheduler) executeCycle(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "ExecuteRotationCycle")
 	defer span.End()
 
-	tokenCount := int64(len(s.config.Tokens))
-	span.SetAttributes(attribute.Int64("tokens.count", tokenCount))
+	var totalTokens int64
+	for _, acct := range s.accounts {
+		totalTokens += int64(len(acct.Tokens))
+	}
+	span.SetAttributes(
+		attribute.Int64("tokens.count", totalTokens),
+		attribute.Int("accounts.count", len(s.accounts)),
+	)
 
-	attrs := append([]any{slog.Int64("token_count", tokenCount)}, observability.TraceAttrs(ctx)...)
+	attrs := append([]any{
+		slog.Int64("token_count", totalTokens),
+		slog.Int("account_count", len(s.accounts)),
+	}, observability.TraceAttrs(ctx)...)
 	logger.InfoContext(ctx, "Starting rotation cycle", attrs...)
 
 	// Record total configured tokens
-	observability.RecordTokenCount(ctx, tokenCount)
+	observability.RecordTokenCount(ctx, totalTokens)
 
-	if tokenCount == 0 {
+	if totalTokens == 0 {
 		logger.InfoContext(ctx, "No tokens configured", observability.TraceAttrs(ctx)...)
 		span.SetStatus(codes.Ok, "no tokens configured")
 		return nil
 	}
 
-	// Process each token
-	for _, tokenConfig := range s.config.Tokens {
-		// Determine threshold (use token-specific if set, otherwise global)
-		threshold := s.config.Rotation.ThresholdPercent
-		if tokenConfig.RotationThreshold > 0 {
-			threshold = tokenConfig.RotationThreshold
-		}
+	// Process each account's tokens
+	var failures int
+	for _, acct := range s.accounts {
+		acctAttrs := append([]any{
+			slog.String("account_label", acct.Account.Label),
+			slog.String("account_team", acct.Account.Team),
+			slog.Int("token_count", len(acct.Tokens)),
+		}, observability.TraceAttrs(ctx)...)
+		logger.InfoContext(ctx, "Processing account", acctAttrs...)
 
-		if err := s.engine.ProcessToken(ctx, tokenConfig, threshold); err != nil {
-			attrs := append([]any{
-				slog.String("token_label", tokenConfig.Label),
-				slog.Any("error", err),
-			}, observability.TraceAttrs(ctx)...)
-			logger.ErrorContext(ctx, "Failed to process token", attrs...)
-			// Continue processing other tokens
+		for _, tokenConfig := range acct.Tokens {
+			// Determine threshold (use token-specific if set, otherwise account-level)
+			threshold := acct.Rotation.ThresholdPercent
+			if tokenConfig.RotationThreshold > 0 {
+				threshold = tokenConfig.RotationThreshold
+			}
+
+			if err := acct.Engine.ProcessToken(ctx, tokenConfig, threshold); err != nil {
+				failures++
+				attrs := append([]any{
+					slog.String("account_label", acct.Account.Label),
+					slog.String("token_label", tokenConfig.Label),
+					slog.Any("error", err),
+				}, observability.TraceAttrs(ctx)...)
+				logger.ErrorContext(ctx, "Failed to process token", attrs...)
+				// Continue processing other tokens
+			}
 		}
+	}
+
+	span.SetAttributes(attribute.Int("tokens.failures", failures))
+
+	if failures > 0 && int64(failures) == totalTokens {
+		span.SetStatus(codes.Error, "all tokens failed")
+		return fmt.Errorf("rotation cycle failed: all %d tokens encountered errors", failures)
+	}
+
+	if failures > 0 {
+		logger.WarnContext(ctx, "Rotation cycle completed with failures",
+			append([]any{slog.Int("failures", failures)}, observability.TraceAttrs(ctx)...)...)
+		span.SetStatus(codes.Error, "rotation cycle completed with failures")
+		return nil
 	}
 
 	logger.InfoContext(ctx, "Rotation cycle completed", observability.TraceAttrs(ctx)...)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -24,70 +24,106 @@ func (m *MockEngine) ProcessToken(ctx context.Context, tokenConfig config.TokenC
 func TestScheduler_RunOnce(t *testing.T) {
 	mockEngine := new(MockEngine)
 
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode: "one-shot",
-		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10,
-		},
-		Tokens: []config.TokenConfig{
-			{
-				Label:    "token1",
-				Team:     "team1",
-				Validity: "90d",
-				Scopes:   "*",
-				Storage:  []config.StorageConfig{{Type: "vault", Path: "path1"}},
-			},
-			{
-				Label:    "token2",
-				Team:     "team2",
-				Validity: "180d",
-				Scopes:   "*",
-				Storage:  []config.StorageConfig{{Type: "vault", Path: "path2"}},
-			},
+	tokens := []config.TokenConfig{
+		{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+		{Label: "token2", Team: "team2", Validity: "180d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path2"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
 		},
 	}
 
-	// Expect ProcessToken to be called for each token
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[0], 10).Return(nil)
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[1], 10).Return(nil)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 10).Return(nil)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[1], 10).Return(nil)
 
-	scheduler := NewScheduler(cfg, mockEngine)
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
 
 	ctx := context.Background()
-	err := scheduler.Run(ctx)
+	err := sched.Run(ctx)
 	require.NoError(t, err)
 
 	mockEngine.AssertExpectations(t)
 }
 
-func TestScheduler_RunDaemon(t *testing.T) {
-	mockEngine := new(MockEngine)
+func TestScheduler_RunOnce_MultipleAccounts(t *testing.T) {
+	mockEngine1 := new(MockEngine)
+	mockEngine2 := new(MockEngine)
 
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode:          "daemon",
-			CheckInterval: "100ms", // Short interval for testing
+	tokens1 := []config.TokenConfig{
+		{Label: "prod-token", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+	}
+	tokens2 := []config.TokenConfig{
+		{Label: "staging-token", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path2"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens1,
+			Engine:   mockEngine1,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
 		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10,
-		},
-		Tokens: []config.TokenConfig{
-			{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+		{
+			Account:  config.AccountConfig{Label: "staging"},
+			Tokens:   tokens2,
+			Engine:   mockEngine2,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
 		},
 	}
 
-	// Expect ProcessToken to be called multiple times
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[0], 10).Return(nil)
+	mockEngine1.On("ProcessToken", mock.Anything, tokens1[0], 10).Return(nil)
+	mockEngine2.On("ProcessToken", mock.Anything, tokens2[0], 10).Return(nil)
 
-	scheduler := NewScheduler(cfg, mockEngine)
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
+
+	ctx := context.Background()
+	err := sched.Run(ctx)
+	require.NoError(t, err)
+
+	// Each engine should have been called with its own account's tokens
+	mockEngine1.AssertExpectations(t)
+	mockEngine2.AssertExpectations(t)
+}
+
+func TestScheduler_RunDaemon(t *testing.T) {
+	mockEngine := new(MockEngine)
+
+	tokens := []config.TokenConfig{
+		{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
+		},
+	}
+
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 10).Return(nil)
+
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "daemon", CheckInterval: "100ms"},
+		accounts,
+	)
 
 	// Create a context that will be cancelled after a short time
 	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
 
-	err := scheduler.Run(ctx)
+	err := sched.Run(ctx)
 	// Context cancellation is expected
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -105,22 +141,25 @@ func TestScheduler_RunDaemon(t *testing.T) {
 func TestScheduler_RunDaemon_GracefulShutdown(t *testing.T) {
 	mockEngine := new(MockEngine)
 
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode:          "daemon",
-			CheckInterval: "1s",
-		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10,
-		},
-		Tokens: []config.TokenConfig{
-			{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+	tokens := []config.TokenConfig{
+		{Label: "token1", Team: "team1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "path1"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
 		},
 	}
 
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[0], 10).Return(nil)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 10).Return(nil)
 
-	scheduler := NewScheduler(cfg, mockEngine)
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "daemon", CheckInterval: "1s"},
+		accounts,
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -130,43 +169,47 @@ func TestScheduler_RunDaemon_GracefulShutdown(t *testing.T) {
 		cancel()
 	}()
 
-	err := scheduler.Run(ctx)
+	err := sched.Run(ctx)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 
 	// Should have run at least once
-	mockEngine.AssertCalled(t, "ProcessToken", mock.Anything, cfg.Tokens[0], 10)
+	mockEngine.AssertCalled(t, "ProcessToken", mock.Anything, tokens[0], 10)
 }
 
 func TestScheduler_TokenRotationThresholdOverride(t *testing.T) {
 	mockEngine := new(MockEngine)
 
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode: "one-shot",
-		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10, // Global threshold
-		},
-		Tokens: []config.TokenConfig{
-			{
-				Label:             "token-with-override",
-				Team:              "team1",
-				Validity:          "90d",
-				Scopes:            "*",
-				RotationThreshold: 20, // Token-specific override
-				Storage:           []config.StorageConfig{{Type: "vault", Path: "path1"}},
-			},
+	tokens := []config.TokenConfig{
+		{
+			Label:             "token-with-override",
+			Team:              "team1",
+			Validity:          "90d",
+			Scopes:            "*",
+			RotationThreshold: 20, // Token-specific override
+			Storage:           []config.StorageConfig{{Type: "vault", Path: "path1"}},
 		},
 	}
 
-	// Should use the token-specific threshold (20) instead of global (10)
-	mockEngine.On("ProcessToken", mock.Anything, cfg.Tokens[0], 20).Return(nil)
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
+		},
+	}
 
-	scheduler := NewScheduler(cfg, mockEngine)
+	// Should use the token-specific threshold (20) instead of account-level (10)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 20).Return(nil)
+
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
 
 	ctx := context.Background()
-	err := scheduler.Run(ctx)
+	err := sched.Run(ctx)
 	require.NoError(t, err)
 
 	mockEngine.AssertExpectations(t)
@@ -174,23 +217,84 @@ func TestScheduler_TokenRotationThresholdOverride(t *testing.T) {
 
 func TestScheduler_NoTokensConfigured(t *testing.T) {
 	mockEngine := new(MockEngine)
-
-	cfg := &config.Config{
-		Daemon: config.DaemonConfig{
-			Mode: "one-shot",
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "empty"},
+			Tokens:   []config.TokenConfig{},
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
 		},
-		Rotation: config.RotationConfig{
-			ThresholdPercent: 10,
-		},
-		Tokens: []config.TokenConfig{}, // No tokens
 	}
 
-	scheduler := NewScheduler(cfg, mockEngine)
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
 
 	ctx := context.Background()
-	err := scheduler.Run(ctx)
+	err := sched.Run(ctx)
 	require.NoError(t, err)
 
-	// ProcessToken should not be called
-	mockEngine.AssertNotCalled(t, "ProcessToken")
+	mockEngine.AssertNotCalled(t, "ProcessToken", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestScheduler_AllTokensFail_ReturnsError(t *testing.T) {
+	mockEngine := new(MockEngine)
+
+	tokens := []config.TokenConfig{
+		{Label: "token1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "p1"}}},
+		{Label: "token2", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "p2"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
+		},
+	}
+
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 10).Return(assert.AnError)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[1], 10).Return(assert.AnError)
+
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
+
+	err := sched.Run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 2 tokens encountered errors")
+	mockEngine.AssertExpectations(t)
+}
+
+func TestScheduler_PartialFailure_ReturnsNil(t *testing.T) {
+	mockEngine := new(MockEngine)
+
+	tokens := []config.TokenConfig{
+		{Label: "token1", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "p1"}}},
+		{Label: "token2", Validity: "90d", Scopes: "*", Storage: []config.StorageConfig{{Type: "vault", Path: "p2"}}},
+	}
+
+	accounts := []AccountEntry{
+		{
+			Account:  config.AccountConfig{Label: "production"},
+			Tokens:   tokens,
+			Engine:   mockEngine,
+			Rotation: config.RotationConfig{ThresholdPercent: 10},
+		},
+	}
+
+	mockEngine.On("ProcessToken", mock.Anything, tokens[0], 10).Return(assert.AnError)
+	mockEngine.On("ProcessToken", mock.Anything, tokens[1], 10).Return(nil)
+
+	sched := NewScheduler(
+		config.DaemonConfig{Mode: "one-shot"},
+		accounts,
+	)
+
+	err := sched.Run(context.Background())
+	require.NoError(t, err, "partial failure should not return an error")
+	mockEngine.AssertExpectations(t)
 }

--- a/internal/vault/client.go
+++ b/internal/vault/client.go
@@ -2,7 +2,9 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -65,48 +67,109 @@ func authenticateAppRole(client *api.Client, roleID, secretID string) error {
 	return nil
 }
 
-// WriteToken writes a token value to a KV v2 path
-func (c *Client) WriteToken(ctx context.Context, path string, token string) error {
+// WriteToken writes a token value to a KV v2 path.
+// The key parameter specifies the key name within the secret. If empty, defaults to "token".
+// Uses JSON Merge Patch (PATCH) to update only the specified key, preserving any other
+// keys that may exist at the same path (e.g., multiple accounts sharing a secret path).
+func (c *Client) WriteToken(ctx context.Context, path, key, token string) error {
+	if key == "" {
+		key = "token"
+	}
+
 	fullPath := fmt.Sprintf("%s/data/%s", c.mountPath, path)
 
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
-			"token": token,
+			key: token,
 		},
 	}
 
-	_, err := c.client.Logical().WriteWithContext(ctx, fullPath, data)
+	_, err := c.client.Logical().JSONMergePatch(ctx, fullPath, data)
 	if err != nil {
-		return fmt.Errorf("failed to write token to vault: %w", err)
+		var respErr *api.ResponseError
+		if !errors.As(err, &respErr) {
+			return fmt.Errorf("failed to patch token in vault: %w", err)
+		}
+
+		switch respErr.StatusCode {
+		case http.StatusNotFound:
+			// Secret doesn't exist yet — safe to do a full write
+			_, err = c.client.Logical().WriteWithContext(ctx, fullPath, data)
+			if err != nil {
+				return fmt.Errorf("failed to write token to vault: %w", err)
+			}
+		case http.StatusForbidden, http.StatusMethodNotAllowed:
+			// PATCH not permitted (403) or not supported (405) — read
+			// existing data, merge, then write to preserve sibling keys
+			merged, readErr := c.readMergeData(ctx, fullPath, key, token)
+			if readErr != nil {
+				return fmt.Errorf("failed to read existing secret for merge: %w", readErr)
+			}
+			_, err = c.client.Logical().WriteWithContext(ctx, fullPath, merged)
+			if err != nil {
+				return fmt.Errorf("failed to write merged token to vault: %w", err)
+			}
+		default:
+			return fmt.Errorf("failed to patch token in vault: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// ReadToken reads a token value from a KV v2 path
-func (c *Client) ReadToken(ctx context.Context, path string) (string, error) {
+// readMergeData reads the existing secret at fullPath, merges the given key/value
+// into its data map, and returns the merged payload ready for a full write.
+func (c *Client) readMergeData(ctx context.Context, fullPath, key, token string) (map[string]interface{}, error) {
+	existing, err := c.client.Logical().ReadWithContext(ctx, fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := map[string]interface{}{key: token}
+	if existing != nil && existing.Data != nil {
+		existingData, ok := existing.Data["data"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid existing data structure at path: %s", fullPath)
+		}
+		for k, v := range existingData {
+			if k != key {
+				merged[k] = v
+			}
+		}
+	}
+
+	return map[string]interface{}{"data": merged}, nil
+}
+
+// ReadSecretKey reads a specific key from a KV v2 secret at the given path
+func (c *Client) ReadSecretKey(ctx context.Context, path, key string) (string, error) {
 	fullPath := fmt.Sprintf("%s/data/%s", c.mountPath, path)
 
 	secret, err := c.client.Logical().ReadWithContext(ctx, fullPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read token from vault: %w", err)
+		return "", fmt.Errorf("failed to read secret from vault path %s: %w", path, err)
 	}
 
 	if secret == nil || secret.Data == nil {
-		return "", fmt.Errorf("no data found at path: %s", path)
+		return "", fmt.Errorf("no data found at vault path: %s", path)
 	}
 
 	data, ok := secret.Data["data"].(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("invalid data structure at path: %s", path)
+		return "", fmt.Errorf("invalid data structure at vault path: %s", path)
 	}
 
-	tokenValue, ok := data["token"].(string)
+	rawValue, exists := data[key]
+	if !exists {
+		return "", fmt.Errorf("key %q not found at vault path: %s", key, path)
+	}
+
+	value, ok := rawValue.(string)
 	if !ok {
-		return "", fmt.Errorf("token value not found at path: %s", path)
+		return "", fmt.Errorf("key %q at vault path %s has non-string type %T", key, path, rawValue)
 	}
 
-	return tokenValue, nil
+	return value, nil
 }
 
 // WriteTokenState writes token state to Vault metadata

--- a/internal/vault/client_test.go
+++ b/internal/vault/client_test.go
@@ -23,7 +23,7 @@ func TestNewClient_AppRoleAuth(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
 			}
@@ -67,33 +67,30 @@ func TestNewClient_AuthFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to authenticate")
 }
 
-func TestWriteToken(t *testing.T) {
-	writeCount := 0
+func TestWriteToken_PATCHSuccess(t *testing.T) {
+	var lastMethod string
 	var lastWrittenData map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/auth/approle/login" {
 			w.WriteHeader(http.StatusOK)
-			response := map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
-			}
-			json.NewEncoder(w).Encode(response)
+			})
 			return
 		}
 
-		if r.URL.Path == "/v1/secret/data/test/path" && (r.Method == "POST" || r.Method == "PUT") {
-			writeCount++
+		if r.URL.Path == "/v1/secret/data/test/path" {
+			lastMethod = r.Method
 			var payload map[string]interface{}
 			json.NewDecoder(r.Body).Decode(&payload)
 			lastWrittenData = payload
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"data": map[string]interface{}{
-					"version": 1,
-				},
+				"data": map[string]interface{}{"version": 1},
 			})
 			return
 		}
@@ -102,36 +99,203 @@ func TestWriteToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	config := &Config{
-		Address:   server.URL,
-		RoleID:    "test-role-id",
-		SecretID:  "test-secret-id",
-		MountPath: "secret",
-	}
-
-	client, err := NewClient(config)
+	client, err := NewClient(&Config{
+		Address: server.URL, RoleID: "r", SecretID: "s", MountPath: "secret",
+	})
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	err = client.WriteToken(ctx, "test/path", "my-secret-token")
+	err = client.WriteToken(context.Background(), "test/path", "", "my-secret-token")
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, writeCount)
-	assert.NotNil(t, lastWrittenData)
-
-	// Verify the data structure
+	assert.Equal(t, "PATCH", lastMethod, "WriteToken should use PATCH when it succeeds")
 	data, ok := lastWrittenData["data"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "my-secret-token", data["token"])
 }
 
-func TestReadToken(t *testing.T) {
+func TestWriteToken_FallbackOn404(t *testing.T) {
+	var methods []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/approle/login" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token":   "test-token",
+					"lease_duration": 3600,
+				},
+			})
+			return
+		}
+
+		if r.URL.Path == "/v1/secret/data/test/path" {
+			methods = append(methods, r.Method)
+			if r.Method == "PATCH" {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{"no data at path"}})
+				return
+			}
+			// POST/PUT fallback succeeds
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"version": 1},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Config{
+		Address: server.URL, RoleID: "r", SecretID: "s", MountPath: "secret",
+	})
+	require.NoError(t, err)
+
+	err = client.WriteToken(context.Background(), "test/path", "custom-key", "my-token")
+	require.NoError(t, err)
+
+	require.Len(t, methods, 2)
+	assert.Equal(t, "PATCH", methods[0], "should try PATCH first")
+	assert.Contains(t, []string{"PUT", "POST"}, methods[1], "should fall back to full write on 404 using PUT or POST")
+}
+
+func TestWriteToken_FallbackOn405_PreservesSiblingKeys(t *testing.T) {
+	var methods []string
+	var writtenPayload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/approle/login" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token":   "test-token",
+					"lease_duration": 3600,
+				},
+			})
+			return
+		}
+
+		if r.URL.Path == "/v1/secret/data/test/path" {
+			methods = append(methods, r.Method)
+			if r.Method == "PATCH" {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{"method not allowed"}})
+				return
+			}
+			if r.Method == "GET" {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"data":     map[string]interface{}{"sibling-key": "preserve-me", "old-key": "also-keep"},
+						"metadata": map[string]interface{}{"version": 1},
+					},
+				})
+				return
+			}
+			// PUT/POST write
+			json.NewDecoder(r.Body).Decode(&writtenPayload)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"version": 2},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Config{
+		Address: server.URL, RoleID: "r", SecretID: "s", MountPath: "secret",
+	})
+	require.NoError(t, err)
+
+	err = client.WriteToken(context.Background(), "test/path", "custom-key", "new-token-value")
+	require.NoError(t, err)
+
+	require.Len(t, methods, 3, "should PATCH, GET, then PUT/POST")
+	assert.Equal(t, "PATCH", methods[0])
+	assert.Equal(t, "GET", methods[1])
+	assert.Contains(t, []string{"PUT", "POST"}, methods[2])
+
+	// Verify the written data contains both the new key and existing sibling keys
+	require.NotNil(t, writtenPayload)
+	dataMap, ok := writtenPayload["data"].(map[string]interface{})
+	require.True(t, ok, "payload should have data key")
+	assert.Equal(t, "new-token-value", dataMap["custom-key"], "should contain the new token")
+	assert.Equal(t, "preserve-me", dataMap["sibling-key"], "should preserve existing sibling key")
+	assert.Equal(t, "also-keep", dataMap["old-key"], "should preserve all existing keys")
+}
+
+func TestWriteToken_FallbackOn403(t *testing.T) {
+	var methods []string
+	existingData := map[string]interface{}{
+		"data": map[string]interface{}{
+			"data":     map[string]interface{}{"sibling-key": "preserve-me"},
+			"metadata": map[string]interface{}{"version": 1},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/approle/login" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token":   "test-token",
+					"lease_duration": 3600,
+				},
+			})
+			return
+		}
+
+		if r.URL.Path == "/v1/secret/data/test/path" {
+			methods = append(methods, r.Method)
+			if r.Method == "PATCH" {
+				w.WriteHeader(http.StatusForbidden)
+				json.NewEncoder(w).Encode(map[string]interface{}{"errors": []string{"permission denied"}})
+				return
+			}
+			if r.Method == "GET" {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(existingData)
+				return
+			}
+			// PUT/POST write succeeds
+			var payload map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&payload)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"version": 2},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Config{
+		Address: server.URL, RoleID: "r", SecretID: "s", MountPath: "secret",
+	})
+	require.NoError(t, err)
+
+	err = client.WriteToken(context.Background(), "test/path", "custom-key", "my-token")
+	require.NoError(t, err)
+
+	require.Len(t, methods, 3, "should PATCH, then GET (read existing), then PUT/POST (write merged)")
+	assert.Equal(t, "PATCH", methods[0], "should try PATCH first")
+	assert.Equal(t, "GET", methods[1], "should read existing data for merge")
+	assert.Contains(t, []string{"PUT", "POST"}, methods[2], "should write merged data")
+}
+
+func TestReadSecretKey_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/auth/approle/login" {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
 			}
@@ -144,7 +308,7 @@ func TestReadToken(t *testing.T) {
 			response := map[string]interface{}{
 				"data": map[string]interface{}{
 					"data": map[string]interface{}{
-						"token": "retrieved-secret-token",
+						"my-key": "my-secret-value",
 					},
 					"metadata": map[string]interface{}{
 						"version": 1,
@@ -170,19 +334,35 @@ func TestReadToken(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	token, err := client.ReadToken(ctx, "test/path")
+	value, err := client.ReadSecretKey(ctx, "test/path", "my-key")
 	require.NoError(t, err)
-	assert.Equal(t, "retrieved-secret-token", token)
+	assert.Equal(t, "my-secret-value", value)
 }
 
-func TestReadToken_NotFound(t *testing.T) {
+func TestReadSecretKey_MissingKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/auth/approle/login" {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+
+		if r.URL.Path == "/v1/secret/data/test/path" && r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			response := map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"other-key": "other-value",
+					},
+					"metadata": map[string]interface{}{
+						"version": 1,
+					},
 				},
 			}
 			json.NewEncoder(w).Encode(response)
@@ -204,9 +384,10 @@ func TestReadToken_NotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	token, err := client.ReadToken(ctx, "nonexistent/path")
+	value, err := client.ReadSecretKey(ctx, "test/path", "nonexistent-key")
 	require.Error(t, err)
-	assert.Empty(t, token)
+	assert.Empty(t, value)
+	assert.Contains(t, err.Error(), "nonexistent-key")
 }
 
 func TestWriteTokenState(t *testing.T) {
@@ -217,7 +398,7 @@ func TestWriteTokenState(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
 			}
@@ -248,13 +429,13 @@ func TestWriteTokenState(t *testing.T) {
 	require.NoError(t, err)
 
 	state := &models.TokenState{
-		Label:              "test-token",
-		CurrentLinodeID:    123,
-		CurrentTokenValue:  "secret-value",
-		LastRotatedAt:      time.Now(),
-		PreviousLinodeID:   100,
-		PreviousExpiresAt:  time.Now().Add(60 * 24 * time.Hour),
-		RotationCount:      5,
+		Label:             "test-token",
+		CurrentLinodeID:   123,
+		CurrentTokenValue: "secret-value",
+		LastRotatedAt:     time.Now(),
+		PreviousLinodeID:  100,
+		PreviousExpiresAt: time.Now().Add(60 * 24 * time.Hour),
+		RotationCount:     5,
 	}
 
 	ctx := context.Background()
@@ -276,7 +457,7 @@ func TestReadTokenState(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
 			}
@@ -289,12 +470,12 @@ func TestReadTokenState(t *testing.T) {
 			response := map[string]interface{}{
 				"data": map[string]interface{}{
 					"custom_metadata": map[string]interface{}{
-						"label":                "test-token",
-						"current_linode_id":    "123",
-						"last_rotated_at":      now.Format(time.RFC3339),
-						"previous_linode_id":   "100",
-						"previous_expires_at":  now.Add(60 * 24 * time.Hour).Format(time.RFC3339),
-						"rotation_count":       "5",
+						"label":               "test-token",
+						"current_linode_id":   "123",
+						"last_rotated_at":     now.Format(time.RFC3339),
+						"previous_linode_id":  "100",
+						"previous_expires_at": now.Add(60 * 24 * time.Hour).Format(time.RFC3339),
+						"rotation_count":      "5",
 					},
 				},
 			}
@@ -333,7 +514,7 @@ func TestReadTokenState_NotFound(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			response := map[string]interface{}{
 				"auth": map[string]interface{}{
-					"client_token": "test-token",
+					"client_token":   "test-token",
 					"lease_duration": 3600,
 				},
 			}

--- a/pkg/models/token.go
+++ b/pkg/models/token.go
@@ -6,26 +6,26 @@ import (
 
 // Token represents a Linode API token with its metadata
 type Token struct {
-	ID        int       // Linode token ID
-	Label     string    // Token label/name
-	Token     string    // The actual token value (secret)
-	CreatedAt time.Time // When the token was created
-	ExpiresAt time.Time // When the token expires
-	Scopes    string    // Token scopes
-	Team      string    // Owning team (metadata)
+	ID        int           // Linode token ID
+	Label     string        // Token label/name
+	Token     string        // The actual token value (secret)
+	CreatedAt time.Time     // When the token was created
+	ExpiresAt time.Time     // When the token expires
+	Scopes    string        // Token scopes
+	Team      string        // Owning team (metadata)
 	Validity  time.Duration // How long the token is valid for
 }
 
 // TokenState represents the current state of a managed token
 // This is stored in Vault metadata to track rotation history
 type TokenState struct {
-	Label              string    // Token label (matches config)
-	CurrentLinodeID    int       // Current active token ID in Linode
-	CurrentTokenValue  string    // Current token value
-	LastRotatedAt      time.Time // When the token was last rotated
-	PreviousLinodeID   int       // Previous token ID (not yet deleted)
-	PreviousExpiresAt  time.Time // When the previous token expires
-	RotationCount      int       // How many times the token has been rotated
+	Label             string    // Token label (matches config)
+	CurrentLinodeID   int       // Current active token ID in Linode
+	CurrentTokenValue string    // Current token value
+	LastRotatedAt     time.Time // When the token was last rotated
+	PreviousLinodeID  int       // Previous token ID (not yet deleted)
+	PreviousExpiresAt time.Time // When the previous token expires
+	RotationCount     int       // How many times the token has been rotated
 }
 
 // NeedsRotation determines if a token needs to be rotated based on the threshold percentage
@@ -52,7 +52,7 @@ func (t *Token) TimeUntilExpiry() time.Duration {
 
 // PercentValidityRemaining calculates what percentage of the token's validity period remains
 func (t *Token) PercentValidityRemaining() float64 {
-	if t.IsExpired() {
+	if t.IsExpired() || t.Validity.Seconds() == 0 {
 		return 0.0
 	}
 

--- a/pkg/models/token_test.go
+++ b/pkg/models/token_test.go
@@ -13,14 +13,14 @@ func TestNewToken(t *testing.T) {
 	expiry := now.Add(90 * 24 * time.Hour)
 
 	token := &Token{
-		ID:          123,
-		Label:       "test-token",
-		Token:       "test-secret-token",
-		CreatedAt:   now,
-		ExpiresAt:   expiry,
-		Scopes:      "*",
-		Team:        "platform-team",
-		Validity:    90 * 24 * time.Hour,
+		ID:        123,
+		Label:     "test-token",
+		Token:     "test-secret-token",
+		CreatedAt: now,
+		ExpiresAt: expiry,
+		Scopes:    "*",
+		Team:      "platform-team",
+		Validity:  90 * 24 * time.Hour,
 	}
 
 	assert.Equal(t, 123, token.ID)
@@ -32,43 +32,43 @@ func TestNewToken(t *testing.T) {
 
 func TestTokenNeedsRotation(t *testing.T) {
 	tests := []struct {
-		name              string
-		expiresAt         time.Time
-		validity          time.Duration
-		thresholdPercent  int
-		expectedNeedsRot  bool
+		name             string
+		expiresAt        time.Time
+		validity         time.Duration
+		thresholdPercent int
+		expectedNeedsRot bool
 	}{
 		{
 			name:             "needs rotation - at 10% threshold",
-			expiresAt:        time.Now().Add(9 * 24 * time.Hour),  // 9 days left
-			validity:         90 * 24 * time.Hour,                  // 90 day validity
-			thresholdPercent: 10,                                   // 10% = 9 days
+			expiresAt:        time.Now().Add(9 * 24 * time.Hour), // 9 days left
+			validity:         90 * 24 * time.Hour,                // 90 day validity
+			thresholdPercent: 10,                                 // 10% = 9 days
 			expectedNeedsRot: true,
 		},
 		{
 			name:             "needs rotation - below 10% threshold",
-			expiresAt:        time.Now().Add(5 * 24 * time.Hour),  // 5 days left
-			validity:         90 * 24 * time.Hour,                  // 90 day validity
+			expiresAt:        time.Now().Add(5 * 24 * time.Hour), // 5 days left
+			validity:         90 * 24 * time.Hour,                // 90 day validity
 			thresholdPercent: 10,
 			expectedNeedsRot: true,
 		},
 		{
 			name:             "does not need rotation - above 10% threshold",
 			expiresAt:        time.Now().Add(15 * 24 * time.Hour), // 15 days left
-			validity:         90 * 24 * time.Hour,                  // 90 day validity
+			validity:         90 * 24 * time.Hour,                 // 90 day validity
 			thresholdPercent: 10,
 			expectedNeedsRot: false,
 		},
 		{
 			name:             "needs rotation - custom 20% threshold",
 			expiresAt:        time.Now().Add(18 * 24 * time.Hour), // 18 days left
-			validity:         90 * 24 * time.Hour,                  // 90 day validity
-			thresholdPercent: 20,                                   // 20% = 18 days
+			validity:         90 * 24 * time.Hour,                 // 90 day validity
+			thresholdPercent: 20,                                  // 20% = 18 days
 			expectedNeedsRot: true,
 		},
 		{
 			name:             "already expired",
-			expiresAt:        time.Now().Add(-1 * time.Hour),      // Already expired
+			expiresAt:        time.Now().Add(-1 * time.Hour), // Already expired
 			validity:         90 * 24 * time.Hour,
 			thresholdPercent: 10,
 			expectedNeedsRot: true,
@@ -91,23 +91,23 @@ func TestTokenNeedsRotation(t *testing.T) {
 
 func TestTokenIsExpired(t *testing.T) {
 	tests := []struct {
-		name           string
-		expiresAt      time.Time
+		name            string
+		expiresAt       time.Time
 		expectedExpired bool
 	}{
 		{
-			name:           "not expired - future date",
-			expiresAt:      time.Now().Add(10 * 24 * time.Hour),
+			name:            "not expired - future date",
+			expiresAt:       time.Now().Add(10 * 24 * time.Hour),
 			expectedExpired: false,
 		},
 		{
-			name:           "expired - past date",
-			expiresAt:      time.Now().Add(-1 * time.Hour),
+			name:            "expired - past date",
+			expiresAt:       time.Now().Add(-1 * time.Hour),
 			expectedExpired: true,
 		},
 		{
-			name:           "expired - just now",
-			expiresAt:      time.Now().Add(-1 * time.Second),
+			name:            "expired - just now",
+			expiresAt:       time.Now().Add(-1 * time.Second),
 			expectedExpired: true,
 		},
 	}
@@ -140,24 +140,24 @@ func TestTokenTimeUntilExpiry(t *testing.T) {
 
 func TestTokenPercentValidityRemaining(t *testing.T) {
 	tests := []struct {
-		name              string
-		createdAt         time.Time
-		expiresAt         time.Time
-		validity          time.Duration
-		expectedPercent   float64
+		name            string
+		createdAt       time.Time
+		expiresAt       time.Time
+		validity        time.Duration
+		expectedPercent float64
 	}{
 		{
 			name:            "50% remaining",
 			createdAt:       time.Now().Add(-45 * 24 * time.Hour), // Created 45 days ago
 			expiresAt:       time.Now().Add(45 * 24 * time.Hour),  // Expires in 45 days
-			validity:        90 * 24 * time.Hour,                   // 90 day validity
+			validity:        90 * 24 * time.Hour,                  // 90 day validity
 			expectedPercent: 50.0,
 		},
 		{
 			name:            "10% remaining",
 			createdAt:       time.Now().Add(-81 * 24 * time.Hour), // Created 81 days ago
 			expiresAt:       time.Now().Add(9 * 24 * time.Hour),   // Expires in 9 days
-			validity:        90 * 24 * time.Hour,                   // 90 day validity
+			validity:        90 * 24 * time.Hour,                  // 90 day validity
 			expectedPercent: 10.0,
 		},
 		{
@@ -186,13 +186,13 @@ func TestTokenPercentValidityRemaining(t *testing.T) {
 
 func TestTokenState(t *testing.T) {
 	state := &TokenState{
-		Label:              "test-token",
-		CurrentLinodeID:    123,
-		CurrentTokenValue:  "current-secret",
-		LastRotatedAt:      time.Now().Add(-30 * 24 * time.Hour),
-		PreviousLinodeID:   100,
-		PreviousExpiresAt:  time.Now().Add(60 * 24 * time.Hour),
-		RotationCount:      5,
+		Label:             "test-token",
+		CurrentLinodeID:   123,
+		CurrentTokenValue: "current-secret",
+		LastRotatedAt:     time.Now().Add(-30 * 24 * time.Hour),
+		PreviousLinodeID:  100,
+		PreviousExpiresAt: time.Now().Add(60 * 24 * time.Hour),
+		RotationCount:     5,
 	}
 
 	assert.Equal(t, "test-token", state.Label)
@@ -207,13 +207,13 @@ func TestTokenStateAfterRotation(t *testing.T) {
 
 	// Initial state
 	state := &TokenState{
-		Label:              "test-token",
-		CurrentLinodeID:    100,
-		CurrentTokenValue:  "old-secret",
-		LastRotatedAt:      now.Add(-80 * 24 * time.Hour),
-		PreviousLinodeID:   0,
-		PreviousExpiresAt:  time.Time{},
-		RotationCount:      0,
+		Label:             "test-token",
+		CurrentLinodeID:   100,
+		CurrentTokenValue: "old-secret",
+		LastRotatedAt:     now.Add(-80 * 24 * time.Hour),
+		PreviousLinodeID:  0,
+		PreviousExpiresAt: time.Time{},
+		RotationCount:     0,
 	}
 
 	// After rotation
@@ -226,13 +226,13 @@ func TestTokenStateAfterRotation(t *testing.T) {
 
 	// Update state
 	newState := &TokenState{
-		Label:              state.Label,
-		CurrentLinodeID:    newToken.ID,
-		CurrentTokenValue:  newToken.Token,
-		LastRotatedAt:      now,
-		PreviousLinodeID:   state.CurrentLinodeID,    // Old becomes previous
-		PreviousExpiresAt:  oldExpiry,                // Old expiry
-		RotationCount:      state.RotationCount + 1,
+		Label:             state.Label,
+		CurrentLinodeID:   newToken.ID,
+		CurrentTokenValue: newToken.Token,
+		LastRotatedAt:     now,
+		PreviousLinodeID:  state.CurrentLinodeID, // Old becomes previous
+		PreviousExpiresAt: oldExpiry,             // Old expiry
+		RotationCount:     state.RotationCount + 1,
 	}
 
 	assert.Equal(t, 200, newState.CurrentLinodeID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -151,7 +151,7 @@ func initializeVault() error {
 	// Create policy
 	policy := `
 path "secret/data/e2e/*" {
-  capabilities = ["create", "read", "update", "delete"]
+  capabilities = ["create", "read", "update", "patch", "delete"]
 }
 path "secret/metadata/e2e/*" {
   capabilities = ["create", "read", "update", "list", "delete"]
@@ -384,18 +384,22 @@ func TestE2E_CreateToken(t *testing.T) {
 	resetMockLinode(t)
 
 	// Create config file using environment variable references
-	configContent := `daemon:
+	configContent := `account:
+  label: "e2e-create"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+daemon:
   mode: "one-shot"
   dry_run: false
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -455,18 +459,22 @@ func TestE2E_RotateToken(t *testing.T) {
 	t.Logf("Setup old token with ID: %d, expiry: %s", oldTokenID, expiry.Format(time.RFC3339))
 
 	// Create config file using environment variable references
-	configContent := `daemon:
+	configContent := `account:
+  label: "e2e-rotate"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+daemon:
   mode: "one-shot"
   dry_run: false
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -524,18 +532,22 @@ func TestE2E_DryRunMode(t *testing.T) {
 	resetMockLinode(t)
 
 	// Create config file with dry_run enabled using environment variable references
-	configContent := `daemon:
+	configContent := `account:
+  label: "e2e-dryrun"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+daemon:
   mode: "one-shot"
   dry_run: true
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -587,19 +599,23 @@ func TestE2E_DaemonMode(t *testing.T) {
 	setupMockLinodeToken(t, "e2e-test-daemon", expiry)
 
 	// Create config file using environment variable references
-	configContent := `daemon:
+	configContent := `account:
+  label: "e2e-daemon"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
+daemon:
   mode: "daemon"
   check_interval: "5s"
   dry_run: false
 
 rotation:
   threshold_percent: 10
-  prune_expired: false
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:

--- a/test/e2e/testdata/config-create.yaml
+++ b/test/e2e/testdata/config-create.yaml
@@ -1,3 +1,10 @@
+account:
+  label: "e2e-test"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
 daemon:
   mode: "one-shot"
   dry_run: false
@@ -7,8 +14,6 @@ rotation:
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -21,4 +26,4 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/e2e/test-create"
+        path: "e2e/test-create"

--- a/test/e2e/testdata/config-daemon.yaml
+++ b/test/e2e/testdata/config-daemon.yaml
@@ -1,3 +1,10 @@
+account:
+  label: "e2e-test"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
 daemon:
   mode: "daemon"
   check_interval: "5s"
@@ -8,8 +15,6 @@ rotation:
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -22,4 +27,4 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/e2e/test-daemon"
+        path: "e2e/test-daemon"

--- a/test/e2e/testdata/config-dryrun.yaml
+++ b/test/e2e/testdata/config-dryrun.yaml
@@ -1,3 +1,10 @@
+account:
+  label: "e2e-test"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
 daemon:
   mode: "one-shot"
   dry_run: true
@@ -7,8 +14,6 @@ rotation:
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -21,4 +26,4 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/e2e/test-dryrun"
+        path: "e2e/test-dryrun"

--- a/test/e2e/testdata/config-rotate.yaml
+++ b/test/e2e/testdata/config-rotate.yaml
@@ -1,3 +1,10 @@
+account:
+  label: "e2e-test"
+  team: "test-team"
+  vault:
+    role_id: "${VAULT_ROLE_ID}"
+    secret_id: "${VAULT_SECRET_ID}"
+
 daemon:
   mode: "one-shot"
   dry_run: false
@@ -7,8 +14,6 @@ rotation:
 
 vault:
   address: "http://localhost:8200"
-  role_id: "${VAULT_ROLE_ID}"
-  secret_id: "${VAULT_SECRET_ID}"
   mount_path: "secret"
 
 observability:
@@ -21,4 +26,4 @@ tokens:
     scopes: "*"
     storage:
       - type: "vault"
-        path: "secret/data/e2e/test-rotate"
+        path: "e2e/test-rotate"


### PR DESCRIPTION
## Description

(sorry, bigger refactor than i thought it'd be - also Claude generated this PR description)

Adds multi-account support to latr — one latr instance can now manage tokens across multiple Linode accounts, each with its own Vault and Linode API clients.

### Configuration model

Configuration is split into two tiers:

- **Global config** (`global: true`) — provides shared defaults for daemon, rotation, vault, and observability settings. Can optionally include `account` and `tokens` if it also serves as an account config (useful for single-file setups).
- **Per-account configs** — one file per Linode account. Each declares an `account` block and its own `tokens`. Can override `rotation` and `vault` settings from the global config.

Daemon and observability settings are global-only — if a per-account config sets them differently, a warning is logged and the global values are used.

Configs are loaded via a glob pattern (`-config '/etc/latr/*.yaml'`). Each non-global config gets its own Linode API and Vault API clients. Configs are not merged — global defaults are propagated to per-account configs for fields they don't set.

### Credential resolution

Environment variables (`LINODE_TOKEN`, `VAULT_ROLE_ID`, `VAULT_SECRET_ID`, `LINODE_API_URL`) still work as fallbacks, but config file values take precedence. The account's Linode API token can also be sourced from Vault at startup via `account.token.storage`, keeping plaintext secrets out of config files entirely. The Vault key used for account token reads honors `storage.key` if set, falling back to `account.label`.

### Vault write safety

`WriteToken` uses JSON Merge Patch (HTTP PATCH) to update only the specified key within a Vault secret, preserving sibling keys at shared paths. Falls back gracefully when PATCH isn't available:
- **404** (new secret) — full write
- **403** (no `patch` capability) or **405** (method not supported) — read existing data, merge, then write

### Other changes

- **Account token self-rotation**: when `account.token` includes rotation fields (label, validity, scopes), latr manages its own authentication token alongside regular managed tokens. The synthesized token entry inherits `account.team` for consistent logging/tracing.
- **Storage key support**: `storage.key` specifies the key name within a Vault secret (defaults to `"token"`). Keys containing `/` or `..` are rejected during validation for both regular tokens and account tokens. `AllTokens()` respects explicit `storage.key` overrides, defaulting to `account.label` only when unset. Token state metadata uses a derived path when a non-default key is set to avoid collisions.
- **Config validation**: account label uniqueness is enforced. Storage entries are validated for type (`"vault"` only), path, and key format.
- **CreateToken expiry fallback**: defaults to the caller-provided expiry parameter instead of a hardcoded 90-day offset when the API response omits the expiry field.
- **Scheduler**: returns an error when all tokens in a cycle fail instead of silent success.
- **main.go refactor**: post-telemetry logic extracted into `run()` so deferred cleanup (telemetry flush, context cancellation) executes on all exit paths.
- **Helm chart**: updated to reflect single-account deployment scope; token fields use snake_case since they pass through `toYaml` directly into the app config.
- **Dead code removed**: `ReadToken`, `GetToken`, `UpdateToken`, `IsNotFoundError`, `ParseScopes` — none were called by production code.

This should be non-breaking for existing single-config users. The `examples/` directory includes both single-account and multi-account configurations.