### PR TITLE
fix: set correct command for Helm chart

### DIFF
--- a/helm/latr/templates/deployment.yaml
+++ b/helm/latr/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         image: {{ include "latr.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-        - /latr
+        - /usr/local/bin/latr
         args:
         - -config
         - /config/config.yaml


### PR DESCRIPTION
The binary gets placed at `/usr/local/bin/latr` in the Dockerfile: https://github.com/wbh1/latr/blob/main/Dockerfile#L15
Helm needs to run it from there as well. 

```bash
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/latr": stat /latr: no such file or directory: unknown
```
