### PR TITLE
feat: add check-config subcommand for offline config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A Go application for automatically managing and rotating Linode API tokens with 
 - **Graceful Token Management**: Keeps old tokens until expiration (configurable pruning)
 - **Multiple Tokens**: Manage multiple API tokens with different configurations
 - **Team Metadata**: Associate tokens with owning teams for organization
-- **Flexible Configuration**: Single YAML file or glob pattern support
+- **Flexible Configuration**: Single YAML file, glob patterns, or multi-file process + token configs
+- **Config Validation**: `latr check-config` for CI (same rules as the daemon; no side effects)
 - **Daemon or One-Shot**: Run as a long-running daemon or one-time execution
 - **Dry-Run Mode**: Test configuration without making changes
 - **OpenTelemetry Support**: Observability via traces, metrics, and logs
@@ -207,10 +208,50 @@ Use a glob pattern to load multiple config files:
 ./latr -config "configs/*.yaml"
 ```
 
+### Validate Configuration (`check-config`)
+
+Validate config using the **same** parse / default / validate path as the daemon, without contacting Linode or Vault. Intended for CI and local PR checks.
+
+```bash
+# Classic single file (public / OSS)
+latr check-config --config config.yaml
+
+# Glob or multiple files (merged; tokens appended)
+latr check-config --config 'configs/*.yaml'
+latr check-config --config base.yaml --config tokens.yaml
+
+# Multi-file process + token configs (shared process settings + team token files)
+latr check-config \
+  --process process.yaml \
+  --config team-a-config.yml \
+  --config team-b-config.yml
+
+# Directory: expects _process.yaml plus one or more other *.yml / *.yaml token files
+latr check-config --dir path/to/config-dir
+```
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Config is valid |
+| `1` | Config is invalid |
+| `2` | Usage / flag error |
+
+Notes:
+
+- Empty Vault `role_id` / `secret_id` after `${VAR}` expansion are **allowed by default** so CI can validate structure without live AppRole secrets. Pass `--require-vault-credentials` to enforce them.
+- Duplicate token **labels** across merged files are rejected.
+- No network calls (no Linode, no Vault login).
+
+```bash
+latr check-config -h
+```
+
 ### Version Information
 
 ```bash
 ./latr -version
+# or
+./latr version
 ```
 
 ## How It Works

--- a/cmd/latr/check_config.go
+++ b/cmd/latr/check_config.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/linode-obs/latr/internal/config"
+)
+
+// multiFlag collects repeated flag values (e.g. --config a --config b).
+type multiFlag []string
+
+func (m *multiFlag) String() string {
+	return strings.Join(*m, ",")
+}
+
+func (m *multiFlag) Set(value string) error {
+	if value == "" {
+		return fmt.Errorf("value must not be empty")
+	}
+	*m = append(*m, value)
+	return nil
+}
+
+// runCheckConfig validates configuration without contacting Linode or Vault.
+// Exit 0 when valid; non-zero when invalid or usage error.
+func runCheckConfig(args []string) int {
+	fs := flag.NewFlagSet("check-config", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var configs multiFlag
+	fs.Var(&configs, "config", "Config file path or glob (repeatable; classic single-file / multi-file merge)")
+	processPath := fs.String("process", "", "Process config file; requires one or more --config token files")
+	dirPath := fs.String("dir", "", "Directory containing _process.yaml plus one or more token YAML files")
+	requireVaultCreds := fs.Bool(
+		"require-vault-credentials",
+		false,
+		"Fail if vault role_id/secret_id are empty after env expansion (default: allow empty for CI)",
+	)
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: latr check-config [flags]
+
+Validate configuration using the same parse/default/validate path as the daemon.
+Does not contact Linode or Vault. Exit 0 if valid, non-zero otherwise.
+
+Modes (pick one):
+  Classic single file or glob:
+    latr check-config --config config.yaml
+    latr check-config --config 'configs/*.yaml'
+
+  Multi-file (process + token files):
+    latr check-config --process process.yaml --config team-a.yml --config team-b.yml
+
+  Directory layout (_process.yaml + token files under one dir):
+    latr check-config --dir path/to/config-dir
+
+Flags:
+`)
+		fs.PrintDefaults()
+		fmt.Fprintf(os.Stderr, `
+Notes:
+  - Empty vault role_id/secret_id after ${VAR} expansion are accepted by default
+    so CI can validate structure without live AppRole secrets.
+  - Pass --require-vault-credentials to enforce non-empty credentials.
+  - Duplicate token labels across merged files are rejected.
+`)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		// flag package already prints usage on -h / parse errors
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "check-config: unexpected arguments: %v\n", fs.Args())
+		fs.Usage()
+		return 2
+	}
+
+	modeCount := 0
+	if *dirPath != "" {
+		modeCount++
+	}
+	if *processPath != "" {
+		modeCount++
+	}
+	// classic: --config without --process/--dir
+	classic := *processPath == "" && *dirPath == "" && len(configs) > 0
+	if classic {
+		modeCount++
+	}
+
+	if modeCount == 0 {
+		fmt.Fprintf(os.Stderr, "check-config: specify --config, --dir, or --process with --config\n")
+		fs.Usage()
+		return 2
+	}
+	if modeCount > 1 {
+		fmt.Fprintf(os.Stderr, "check-config: use only one of --dir, --process, or classic --config\n")
+		fs.Usage()
+		return 2
+	}
+	if *processPath != "" && len(configs) == 0 {
+		fmt.Fprintf(os.Stderr, "check-config: --process requires at least one --config token file\n")
+		fs.Usage()
+		return 2
+	}
+	if *dirPath != "" && len(configs) > 0 {
+		fmt.Fprintf(os.Stderr, "check-config: --dir cannot be combined with --config\n")
+		fs.Usage()
+		return 2
+	}
+
+	opts := config.CheckOptions{
+		RequireVaultCredentials: *requireVaultCreds,
+	}
+
+	var (
+		cfg *config.Config
+		err error
+		src string
+	)
+
+	switch {
+	case *dirPath != "":
+		src = *dirPath
+		cfg, err = config.LoadDirAndCheck(*dirPath, opts)
+	case *processPath != "":
+		src = *processPath + " + " + strings.Join(configs, ", ")
+		cfg, err = config.LoadProcessAndTokenConfigsAndCheck(*processPath, configs, opts)
+	case len(configs) == 1:
+		src = configs[0]
+		cfg, err = config.LoadAndCheck(configs[0], opts)
+	default:
+		// Multiple --config without --process: merge in flag order
+		src = strings.Join(configs, ", ")
+		cfg, err = config.LoadFilesAndCheck(configs, opts)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "check-config: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf(
+		"OK: %d token(s) valid (%s)\n",
+		len(cfg.Tokens),
+		src,
+	)
+	return 0
+}

--- a/cmd/latr/main.go
+++ b/cmd/latr/main.go
@@ -23,10 +23,54 @@ var (
 	date    = "unknown"
 )
 
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `latr - Linode API Token Rotator
+
+Usage:
+  latr -config <file|glob>     Run rotation (daemon or one-shot per config)
+  latr check-config [flags]    Validate config without Linode/Vault side effects
+  latr version                 Show version information
+
+Daemon flags:
+  -config string
+    	Path to configuration file or glob pattern (required)
+  -version
+    	Show version information
+
+Examples:
+  latr -config config.yaml
+  latr check-config --config config.yaml
+  latr check-config --dir path/to/config-dir
+  latr check-config --process process.yaml --config team-config.yml
+
+Environment (daemon):
+  LINODE_TOKEN       Linode API token (required to run)
+  VAULT_ROLE_ID      Optional if set in config
+  VAULT_SECRET_ID    Optional if set in config
+
+For check-config flags: latr check-config -h
+`)
+}
+
 func main() {
-	// Parse CLI flags
+	// Subcommands (before flag.Parse so daemon flags stay backward-compatible).
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "check-config":
+			os.Exit(runCheckConfig(os.Args[2:]))
+		case "help", "-h", "--help":
+			printUsage()
+			os.Exit(0)
+		case "version", "-version", "--version":
+			fmt.Printf("latr version %s (commit: %s, built: %s)\n", version, commit, date)
+			os.Exit(0)
+		}
+	}
+
+	// Parse CLI flags (daemon / one-shot)
 	configPath := flag.String("config", "", "Path to configuration file or glob pattern (required)")
 	showVersion := flag.Bool("version", false, "Show version information")
+	flag.Usage = printUsage
 	flag.Parse()
 
 	if *showVersion {
@@ -43,6 +87,7 @@ func main() {
 
 	if *configPath == "" {
 		logger.Error("Missing required flag", slog.String("flag", "config"))
+		printUsage()
 		os.Exit(1)
 	}
 

--- a/internal/config/compose.go
+++ b/internal/config/compose.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ProcessConfigFileName is the process-wide config file name for multi-file --dir layouts.
+// Token files are any other *.yml / *.yaml in the same directory.
+const ProcessConfigFileName = "_process.yaml"
+
+// vaultCredentialPlaceholder is used by Check so Validate can run without live AppRole secrets.
+// Config files typically use ${VAULT_ROLE_ID} / ${VAULT_SECRET_ID}; CI leaves those unset.
+const vaultCredentialPlaceholder = "check-config-placeholder"
+
+// LoadFiles loads and merges configuration files in order.
+// Each path may be a literal file or a glob pattern. Non-empty process fields from
+// later files override earlier ones; tokens are appended.
+func LoadFiles(paths []string) (*Config, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no config files specified")
+	}
+
+	expanded, err := expandConfigPaths(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	var merged *Config
+	for _, path := range expanded {
+		cfg, err := Load(path)
+		if err != nil {
+			return nil, err
+		}
+		if merged == nil {
+			merged = cfg
+			continue
+		}
+		merged = MergeConfigs(merged, cfg)
+	}
+	return merged, nil
+}
+
+// expandConfigPaths expands globs in order; literal paths are kept as-is.
+func expandConfigPaths(paths []string) ([]string, error) {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if !containsGlobChar(path) {
+			out = append(out, path)
+			continue
+		}
+		matches, err := filepath.Glob(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob pattern %s: %w", path, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no config files found matching pattern: %s", path)
+		}
+		sort.Strings(matches)
+		out = append(out, matches...)
+	}
+	return out, nil
+}
+
+// LoadDir loads a multi-file config directory: exactly one process file
+// (_process.yaml) plus one or more other YAML token config files.
+func LoadDir(dir string) (*Config, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+
+	var processPath string
+	tokenPaths := make([]string, 0)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !isYAMLConfigFile(name) {
+			continue
+		}
+
+		full := filepath.Join(dir, name)
+		switch name {
+		case ProcessConfigFileName, "_process.yml":
+			if processPath != "" {
+				return nil, fmt.Errorf(
+					"directory %s: multiple process config files (%s and %s); keep a single %s",
+					dir,
+					filepath.Base(processPath),
+					name,
+					ProcessConfigFileName,
+				)
+			}
+			processPath = full
+		default:
+			tokenPaths = append(tokenPaths, full)
+		}
+	}
+
+	if processPath == "" {
+		return nil, fmt.Errorf(
+			"directory %s: missing process config %s",
+			dir,
+			ProcessConfigFileName,
+		)
+	}
+	if len(tokenPaths) == 0 {
+		return nil, fmt.Errorf(
+			"directory %s: need at least one token config file (*.yml / *.yaml) besides %s",
+			dir,
+			ProcessConfigFileName,
+		)
+	}
+
+	sort.Strings(tokenPaths)
+	paths := make([]string, 0, 1+len(tokenPaths))
+	paths = append(paths, processPath)
+	paths = append(paths, tokenPaths...)
+	return LoadFiles(paths)
+}
+
+// LoadProcessAndTokenConfigs loads a process config then merges token-only config files.
+func LoadProcessAndTokenConfigs(processPath string, tokenPaths []string) (*Config, error) {
+	if processPath == "" {
+		return nil, fmt.Errorf("process config path is required")
+	}
+	if len(tokenPaths) == 0 {
+		return nil, fmt.Errorf("at least one token config file is required with --process")
+	}
+
+	paths := make([]string, 0, 1+len(tokenPaths))
+	paths = append(paths, processPath)
+	paths = append(paths, tokenPaths...)
+	return LoadFiles(paths)
+}
+
+// CheckOptions controls Check (CI validation) behavior.
+type CheckOptions struct {
+	// RequireVaultCredentials fails when role_id/secret_id are empty after env expansion.
+	// Default false so CI can validate structure without live AppRole secrets.
+	RequireVaultCredentials bool
+}
+
+// Check applies defaults and validates a loaded config the same way the daemon
+// does, without contacting Linode or Vault.
+//
+// When RequireVaultCredentials is false (default), empty vault role_id/secret_id
+// after ${VAR} expansion are filled with placeholders so Validate can run.
+func Check(cfg *Config, opts CheckOptions) error {
+	if cfg == nil {
+		return fmt.Errorf("config is nil")
+	}
+
+	cfg.ApplyDefaults()
+
+	if !opts.RequireVaultCredentials {
+		if cfg.Vault.RoleID == "" {
+			cfg.Vault.RoleID = vaultCredentialPlaceholder
+		}
+		if cfg.Vault.SecretID == "" {
+			cfg.Vault.SecretID = vaultCredentialPlaceholder
+		}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	if err := validateUniqueTokenLabels(cfg); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+	return nil
+}
+
+// LoadAndCheck loads pathOrPattern (single file or glob), applies defaults, and validates.
+func LoadAndCheck(pathOrPattern string, opts CheckOptions) (*Config, error) {
+	cfg, err := loadPathOrPattern(pathOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	if err := Check(cfg, opts); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadFilesAndCheck loads explicit files in order, applies defaults, and validates.
+func LoadFilesAndCheck(paths []string, opts CheckOptions) (*Config, error) {
+	cfg, err := LoadFiles(paths)
+	if err != nil {
+		return nil, err
+	}
+	if err := Check(cfg, opts); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadDirAndCheck loads a multi-file directory layout and validates it.
+func LoadDirAndCheck(dir string, opts CheckOptions) (*Config, error) {
+	cfg, err := LoadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	if err := Check(cfg, opts); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadProcessAndTokenConfigsAndCheck loads process + token files and validates.
+func LoadProcessAndTokenConfigsAndCheck(
+	processPath string,
+	tokenPaths []string,
+	opts CheckOptions,
+) (*Config, error) {
+	cfg, err := LoadProcessAndTokenConfigs(processPath, tokenPaths)
+	if err != nil {
+		return nil, err
+	}
+	if err := Check(cfg, opts); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func loadPathOrPattern(pathOrPattern string) (*Config, error) {
+	if containsGlobChar(pathOrPattern) {
+		return LoadGlob(pathOrPattern)
+	}
+	return Load(pathOrPattern)
+}
+
+func isYAMLConfigFile(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
+}
+
+func validateUniqueTokenLabels(cfg *Config) error {
+	seen := make(map[string]int, len(cfg.Tokens))
+	for i, token := range cfg.Tokens {
+		label := token.Label
+		if label == "" {
+			continue
+		}
+		if prev, ok := seen[label]; ok {
+			return fmt.Errorf(
+				"duplicate token label %q (token[%d] and token[%d])",
+				label,
+				prev,
+				i,
+			)
+		}
+		seen[label] = i
+	}
+	return nil
+}

--- a/internal/config/compose_test.go
+++ b/internal/config/compose_test.go
@@ -1,0 +1,283 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validProcessYAML = `
+vault:
+  address: "https://vault.example.com"
+  role_id: "${VAULT_ROLE_ID}"
+  secret_id: "${VAULT_SECRET_ID}"
+  mount_path: "infra"
+
+daemon:
+  mode: "daemon"
+  check_interval: "6h"
+
+rotation:
+  threshold_percent: 10
+`
+
+const validTokenYAML = `
+tokens:
+  - label: "workload-a"
+    team: "team-a"
+    validity: "90d"
+    scopes: "linodes:read_only"
+    storage:
+      - type: "vault"
+        path: "shared-all/team-a/workload-a"
+`
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestLoadDir_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", validProcessYAML)
+	writeFile(t, dir, "team-a-config.yml", validTokenYAML)
+	writeFile(t, dir, "team-b-config.yml", `
+tokens:
+  - label: "workload-b"
+    team: "team-b"
+    validity: "180d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "shared-all/team-b/workload-b"
+`)
+
+	cfg, err := LoadDir(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "https://vault.example.com", cfg.Vault.Address)
+	assert.Equal(t, "infra", cfg.Vault.MountPath)
+	assert.Equal(t, "daemon", cfg.Daemon.Mode)
+	require.Len(t, cfg.Tokens, 2)
+
+	labels := []string{cfg.Tokens[0].Label, cfg.Tokens[1].Label}
+	assert.Contains(t, labels, "workload-a")
+	assert.Contains(t, labels, "workload-b")
+}
+
+func TestLoadDir_MissingProcess(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "team-a-config.yml", validTokenYAML)
+
+	cfg, err := LoadDir(dir)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "missing process config")
+}
+
+func TestLoadDir_NoTokenFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", validProcessYAML)
+
+	cfg, err := LoadDir(dir)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "at least one token config")
+}
+
+func TestLoadDir_NotADirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "file.yaml", validProcessYAML)
+
+	cfg, err := LoadDir(path)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "not a directory")
+}
+
+func TestLoadProcessAndTokenConfigs(t *testing.T) {
+	dir := t.TempDir()
+	process := writeFile(t, dir, "_process.yaml", validProcessYAML)
+	token := writeFile(t, dir, "team.yml", validTokenYAML)
+
+	cfg, err := LoadProcessAndTokenConfigs(process, []string{token})
+	require.NoError(t, err)
+	require.Len(t, cfg.Tokens, 1)
+	assert.Equal(t, "workload-a", cfg.Tokens[0].Label)
+}
+
+func TestLoadProcessAndTokenConfigs_RequiresTokenFiles(t *testing.T) {
+	dir := t.TempDir()
+	process := writeFile(t, dir, "_process.yaml", validProcessYAML)
+
+	cfg, err := LoadProcessAndTokenConfigs(process, nil)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "at least one token config")
+}
+
+func TestCheck_AllowsEmptyVaultCredentials(t *testing.T) {
+	// Unset so ${VAULT_*} expand to empty (CI case).
+	t.Setenv("VAULT_ROLE_ID", "")
+	t.Setenv("VAULT_SECRET_ID", "")
+
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", validProcessYAML)
+	writeFile(t, dir, "team.yml", validTokenYAML)
+
+	cfg, err := LoadDir(dir)
+	require.NoError(t, err)
+
+	// After expand, credentials are empty.
+	assert.Empty(t, cfg.Vault.RoleID)
+	assert.Empty(t, cfg.Vault.SecretID)
+
+	err = Check(cfg, CheckOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, vaultCredentialPlaceholder, cfg.Vault.RoleID)
+	assert.Equal(t, vaultCredentialPlaceholder, cfg.Vault.SecretID)
+}
+
+func TestCheck_RequireVaultCredentials(t *testing.T) {
+	t.Setenv("VAULT_ROLE_ID", "")
+	t.Setenv("VAULT_SECRET_ID", "")
+
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", validProcessYAML)
+	writeFile(t, dir, "team.yml", validTokenYAML)
+
+	cfg, err := LoadDir(dir)
+	require.NoError(t, err)
+
+	err = Check(cfg, CheckOptions{RequireVaultCredentials: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "role_id")
+}
+
+func TestCheck_RejectsDuplicateLabels(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", `
+vault:
+  address: "https://vault.example.com"
+  role_id: "role"
+  secret_id: "secret"
+`)
+	writeFile(t, dir, "a.yml", `
+tokens:
+  - label: "same"
+    team: "a"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path/a"
+`)
+	writeFile(t, dir, "b.yml", `
+tokens:
+  - label: "same"
+    team: "b"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path/b"
+`)
+
+	cfg, err := LoadDirAndCheck(dir, CheckOptions{})
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "duplicate token label")
+	assert.Contains(t, err.Error(), "same")
+}
+
+func TestLoadDirAndCheck_OK(t *testing.T) {
+	t.Setenv("VAULT_ROLE_ID", "")
+	t.Setenv("VAULT_SECRET_ID", "")
+
+	dir := t.TempDir()
+	writeFile(t, dir, "_process.yaml", validProcessYAML)
+	writeFile(t, dir, "team.yml", validTokenYAML)
+
+	cfg, err := LoadDirAndCheck(dir, CheckOptions{})
+	require.NoError(t, err)
+	require.Len(t, cfg.Tokens, 1)
+	assert.Equal(t, "workload-a", cfg.Tokens[0].Label)
+}
+
+func TestLoadAndCheck_ClassicSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "config.yaml", `
+vault:
+  address: "https://vault.example.com"
+  role_id: "role"
+  secret_id: "secret"
+
+tokens:
+  - label: "classic"
+    team: "platform"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "secret/data/linode/tokens/classic"
+`)
+
+	cfg, err := LoadAndCheck(path, CheckOptions{RequireVaultCredentials: true})
+	require.NoError(t, err)
+	require.Len(t, cfg.Tokens, 1)
+	assert.Equal(t, "classic", cfg.Tokens[0].Label)
+	assert.Equal(t, "daemon", cfg.Daemon.Mode) // default
+}
+
+func TestLoadAndCheck_InvalidMissingTokens(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "config.yaml", `
+vault:
+  address: "https://vault.example.com"
+  role_id: "role"
+  secret_id: "secret"
+`)
+
+	cfg, err := LoadAndCheck(path, CheckOptions{})
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "at least one token")
+}
+
+func TestLoadFilesAndCheck_MergeOrder(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeFile(t, dir, "base.yaml", `
+vault:
+  address: "https://vault.example.com"
+  role_id: "role"
+  secret_id: "secret"
+tokens:
+  - label: "one"
+    team: "t"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path/one"
+`)
+	p2 := writeFile(t, dir, "extra.yaml", `
+tokens:
+  - label: "two"
+    team: "t"
+    validity: "90d"
+    scopes: "*"
+    storage:
+      - type: "vault"
+        path: "path/two"
+`)
+
+	cfg, err := LoadFilesAndCheck([]string{p1, p2}, CheckOptions{})
+	require.NoError(t, err)
+	require.Len(t, cfg.Tokens, 2)
+}


### PR DESCRIPTION
Adds `latr check-config` so CI and local checks can validate configuration with the **same** load/default/validate logic as the running daemon, with **no** Linode or Vault side effects.

### Usage

```bash
# Classic single file or glob
latr check-config --config config.yaml
latr check-config --config 'configs/*.yaml'

# Multi-file: process settings + token files
latr check-config --process process.yaml --config team-a.yml --config team-b.yml

# Directory: `_process.yaml` + other `*.yml`/`*.yaml` token files
latr check-config --dir path/to/config-dir