### PR TITLE
fix: add team label to per-token metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,10 @@ latr supports OpenTelemetry for observability:
 ### Metrics
 
 - `latr_tokens_total` - Total configured tokens
-- `latr_rotations_total{status="success|failure"}` - Rotation attempts
-- `latr_rotation_duration_seconds` - Rotation operation duration
-- `latr_token_validity_remaining_seconds` - Time until rotation needed
-- `latr_vault_storage_errors_total` - Vault write failures
+- `latr_rotations_total{status,label,team}` - Rotation attempts (per token)
+- `latr_rotation_duration_seconds{label,team}` - Rotation operation duration
+- `latr_token_validity_remaining_seconds{label,team}` - Time until rotation needed
+- `latr_vault_storage_errors_total{path}` - Vault write failures
 
 ### Grafana dashboard & alerts (mixin)
 

--- a/internal/observability/telemetry.go
+++ b/internal/observability/telemetry.go
@@ -211,8 +211,20 @@ func RecordTokenCount(ctx context.Context, count int64) {
 	globalMetrics.TokensTotal.Record(ctx, count)
 }
 
+// tokenMetricAttrs returns attributes for per-token metrics that already use label.
+// team is included so alerts can be routed to the owning team (same value as config team).
+func tokenMetricAttrs(label, team string, extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2+len(extra))
+	attrs = append(attrs,
+		attribute.String("label", label),
+		attribute.String("team", team),
+	)
+	attrs = append(attrs, extra...)
+	return attrs
+}
+
 // RecordRotation records a rotation attempt with success/failure status
-func RecordRotation(ctx context.Context, label string, success bool) {
+func RecordRotation(ctx context.Context, label, team string, success bool) {
 	if globalMetrics == nil {
 		return
 	}
@@ -222,29 +234,28 @@ func RecordRotation(ctx context.Context, label string, success bool) {
 	}
 	globalMetrics.RotationsTotal.Add(ctx, 1,
 		metric.WithAttributes(
-			attribute.String("status", status),
-			attribute.String("label", label),
+			tokenMetricAttrs(label, team, attribute.String("status", status))...,
 		),
 	)
 }
 
 // RecordRotationDuration records the duration of a rotation operation
-func RecordRotationDuration(ctx context.Context, label string, duration time.Duration) {
+func RecordRotationDuration(ctx context.Context, label, team string, duration time.Duration) {
 	if globalMetrics == nil {
 		return
 	}
 	globalMetrics.RotationDuration.Record(ctx, duration.Seconds(),
-		metric.WithAttributes(attribute.String("label", label)),
+		metric.WithAttributes(tokenMetricAttrs(label, team)...),
 	)
 }
 
 // RecordTokenValidityRemaining records the time remaining until rotation is needed
-func RecordTokenValidityRemaining(ctx context.Context, label string, seconds float64) {
+func RecordTokenValidityRemaining(ctx context.Context, label, team string, seconds float64) {
 	if globalMetrics == nil {
 		return
 	}
 	globalMetrics.TokenValidityRemaining.Record(ctx, seconds,
-		metric.WithAttributes(attribute.String("label", label)),
+		metric.WithAttributes(tokenMetricAttrs(label, team)...),
 	)
 }
 

--- a/internal/rotation/engine.go
+++ b/internal/rotation/engine.go
@@ -99,7 +99,7 @@ func (e *Engine) ProcessToken(ctx context.Context, tokenConfig config.TokenConfi
 
 	// Record token validity remaining metric
 	validityRemaining := time.Until(existingToken.ExpiresAt).Seconds()
-	observability.RecordTokenValidityRemaining(ctx, tokenConfig.Label, validityRemaining)
+	observability.RecordTokenValidityRemaining(ctx, tokenConfig.Label, tokenConfig.Team, validityRemaining)
 	span.SetAttributes(attribute.Float64("token.validity_remaining_seconds", validityRemaining))
 
 	if existingToken.NeedsRotation(thresholdPercent) {
@@ -151,7 +151,7 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to read token state")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
 		return fmt.Errorf("failed to read token state: %w", err)
 	}
 
@@ -163,8 +163,8 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to create token")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		return fmt.Errorf("failed to create token %s in Linode: %w", tokenConfig.Label, err)
 	}
 
@@ -181,8 +181,8 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 		_ = e.updateState(ctx, storagePath, newToken, existingState, expiry)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to store token")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		observability.RecordVaultStorageError(ctx, storagePath)
 		return fmt.Errorf("failed to store token in vault: %w", err)
 	}
@@ -191,15 +191,15 @@ func (e *Engine) createNewToken(ctx context.Context, tokenConfig config.TokenCon
 	if err := e.updateState(ctx, storagePath, newToken, existingState, expiry); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to update state")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		return fmt.Errorf("failed to update token state: %w", err)
 	}
 
 	// Record successful rotation
 	span.SetStatus(codes.Ok, "token created successfully")
-	observability.RecordRotation(ctx, tokenConfig.Label, true)
-	observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+	observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, true)
+	observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 
 	return nil
 }
@@ -239,7 +239,7 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to read token state")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
 		return fmt.Errorf("failed to read token state: %w", err)
 	}
 
@@ -251,8 +251,8 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to create token")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		return fmt.Errorf("failed to create token %s in Linode: %w", tokenConfig.Label, err)
 	}
 
@@ -273,8 +273,8 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 		_ = e.updateStateAfterRotation(ctx, storagePath, newToken, existingToken, existingState)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to store token")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		observability.RecordVaultStorageError(ctx, storagePath)
 		return fmt.Errorf("failed to store token in vault: %w", err)
 	}
@@ -283,15 +283,15 @@ func (e *Engine) rotateToken(ctx context.Context, tokenConfig config.TokenConfig
 	if err := e.updateStateAfterRotation(ctx, storagePath, newToken, existingToken, existingState); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to update state")
-		observability.RecordRotation(ctx, tokenConfig.Label, false)
-		observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+		observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, false)
+		observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 		return fmt.Errorf("failed to update token state: %w", err)
 	}
 
 	// Record successful rotation
 	span.SetStatus(codes.Ok, "token rotated successfully")
-	observability.RecordRotation(ctx, tokenConfig.Label, true)
-	observability.RecordRotationDuration(ctx, tokenConfig.Label, time.Since(startTime))
+	observability.RecordRotation(ctx, tokenConfig.Label, tokenConfig.Team, true)
+	observability.RecordRotationDuration(ctx, tokenConfig.Label, tokenConfig.Team, time.Since(startTime))
 
 	return nil
 }

--- a/latr-mixin/README.md
+++ b/latr-mixin/README.md
@@ -14,9 +14,9 @@ Mixins are written in [Jsonnet](https://jsonnet.org/) and are typically installe
 | Metric | Type | Labels |
 | --- | --- | --- |
 | `latr_tokens_total` | gauge | — |
-| `latr_rotations_total` | counter | `status` (`success`\|`failure`), `label` |
-| `latr_token_validity_remaining_seconds` | gauge | `label` |
-| `latr_rotation_duration_seconds_*` | histogram | `label` |
+| `latr_rotations_total` | counter | `status` (`success`\|`failure`), `label`, `team` |
+| `latr_token_validity_remaining_seconds` | gauge | `label`, `team` |
+| `latr_rotation_duration_seconds_*` | histogram | `label`, `team` |
 | `latr_vault_storage_errors_total` | counter | `path` |
 
 latr exports these via OpenTelemetry. Names above assume Prometheus-compatible export (histogram `_bucket` / `_sum` / `_count`).

--- a/latr-mixin/alerts/alerts.libsonnet
+++ b/latr-mixin/alerts/alerts.libsonnet
@@ -20,7 +20,7 @@
           {
             alert: 'LatrTokenRotationFailed',
             expr: |||
-              sum by (label) (
+              sum by (label, team) (
                 increase(latr_rotations_total%(selFailure)s[%(window)s])
               ) > 0
             ||| % {
@@ -34,7 +34,7 @@
             annotations: {
               summary: 'latr failed to rotate a Linode API token.',
               description: |||
-                Token label {{ $labels.label }} has {{ $value | humanize }} failed rotation attempt(s) in the last %(window)s.
+                Token label {{ $labels.label }} (team {{ $labels.team }}) has {{ $value | humanize }} failed rotation attempt(s) in the last %(window)s.
                 Check latr logs for Linode API or Vault errors. After a successful retry, complete CSI follow-up if required.
               ||| % { window: cfg.alertWindow },
             },
@@ -64,7 +64,7 @@
           {
             alert: 'LatrTokenValidityLow',
             expr: |||
-              min by (label) (
+              min by (label, team) (
                 latr_token_validity_remaining_seconds%(sel)s
               ) < %(threshold)s
             ||| % {
@@ -78,7 +78,7 @@
             annotations: {
               summary: 'A managed Linode API token is close to its rotation threshold.',
               description: |||
-                Token label {{ $labels.label }} has only {{ $value | humanizeDuration }} remaining until latr considers rotation needed (threshold %(threshold)s).
+                Token label {{ $labels.label }} (team {{ $labels.team }}) has only {{ $value | humanizeDuration }} remaining until latr considers rotation needed (threshold %(threshold)s).
                 Confirm latr is running and able to reach Linode and Vault.
               ||| % { threshold: cfg.tokenValidityLowSeconds },
             },

--- a/latr-mixin/dashboards/latr.json
+++ b/latr-mixin/dashboards/latr.json
@@ -529,8 +529,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status, label) (rate(latr_rotations_total{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
-          "legendFormat": "{{label}} {{status}}",
+          "expr": "sum by (status, label, team) (rate(latr_rotations_total{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
+          "legendFormat": "{{team}}/{{label}} {{status}}",
           "range": true,
           "refId": "A"
         }
@@ -627,8 +627,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status, label) (increase(latr_rotations_total{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
-          "legendFormat": "{{label}} {{status}}",
+          "expr": "sum by (status, label, team) (increase(latr_rotations_total{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
+          "legendFormat": "{{team}}/{{label}} {{status}}",
           "range": true,
           "refId": "A"
         }
@@ -743,8 +743,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (label) (latr_token_validity_remaining_seconds{__LATR_SELECTOR__,label=~\"$token_label\"})",
-          "legendFormat": "{{label}}",
+          "expr": "max by (label, team) (latr_token_validity_remaining_seconds{__LATR_SELECTOR__,label=~\"$token_label\"})",
+          "legendFormat": "{{team}}/{{label}}",
           "range": true,
           "refId": "A"
         }
@@ -820,10 +820,10 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max by (label) (latr_token_validity_remaining_seconds{__LATR_SELECTOR__,label=~\"$token_label\"}) / 86400",
+          "expr": "max by (label, team) (latr_token_validity_remaining_seconds{__LATR_SELECTOR__,label=~\"$token_label\"}) / 86400",
           "format": "table",
           "instant": true,
-          "legendFormat": "{{label}}",
+          "legendFormat": "{{team}}/{{label}}",
           "refId": "A"
         }
       ],
@@ -948,8 +948,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by (le, label) (rate(latr_rotation_duration_seconds_bucket{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])))",
-          "legendFormat": "p50 {{label}}",
+          "expr": "histogram_quantile(0.50, sum by (le, label, team) (rate(latr_rotation_duration_seconds_bucket{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{team}}/{{label}}",
           "range": true,
           "refId": "A"
         },
@@ -959,8 +959,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, label) (rate(latr_rotation_duration_seconds_bucket{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])))",
-          "legendFormat": "p95 {{label}}",
+          "expr": "histogram_quantile(0.95, sum by (le, label, team) (rate(latr_rotation_duration_seconds_bucket{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{team}}/{{label}}",
           "range": true,
           "refId": "B"
         },
@@ -970,8 +970,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (label) (rate(latr_rotation_duration_seconds_sum{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])) / sum by (label) (rate(latr_rotation_duration_seconds_count{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
-          "legendFormat": "avg {{label}}",
+          "expr": "sum by (label, team) (rate(latr_rotation_duration_seconds_sum{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval])) / sum by (label, team) (rate(latr_rotation_duration_seconds_count{__LATR_SELECTOR__,label=~\"$token_label\"}[$__rate_interval]))",
+          "legendFormat": "avg {{team}}/{{label}}",
           "range": true,
           "refId": "C"
         }
@@ -1108,7 +1108,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "## Metrics\n\n| Metric | Type | Labels |\n| --- | --- | --- |\n| `latr_tokens_total` | gauge | \u2014 |\n| `latr_rotations_total` | counter | `status` (`success`\\|`failure`), `label` |\n| `latr_token_validity_remaining_seconds` | gauge | `label` |\n| `latr_rotation_duration_seconds_*` | histogram | `label` |\n| `latr_vault_storage_errors_total` | counter | `path` |\n\nlatr exports OpenTelemetry metrics (latr_*). Ensure they are exposed to Prometheus in a compatible form (histogram `_bucket` / `_sum` / `_count`).\n\nAfter a successful rotation, verify downstream consumers pick up the new token.",
+        "content": "## Metrics\n\n| Metric | Type | Labels |\n| --- | --- | --- |\n| `latr_tokens_total` | gauge | \u2014 |\n| `latr_rotations_total` | counter | `status` (`success`\\|`failure`), `label`, `team` |\n| `latr_token_validity_remaining_seconds` | gauge | `label`, `team` |\n| `latr_rotation_duration_seconds_*` | histogram | `label`, `team` |\n| `latr_vault_storage_errors_total` | counter | `path` |\n\nlatr exports OpenTelemetry metrics (latr_*). Ensure they are exposed to Prometheus in a compatible form (histogram `_bucket` / `_sum` / `_count`).\n\nAfter a successful rotation, verify downstream consumers pick up the new token.",
         "mode": "markdown"
       },
       "pluginVersion": "10.4.0",


### PR DESCRIPTION
Fixes #76: per-token metrics only had `label`; spans already had `token.team`.

Adds `team` to the same metrics that already use `label`:

- `latr_rotations_total`
- `latr_token_validity_remaining_seconds`
- `latr_rotation_duration_seconds_*`

Leaves `latr_tokens_total` and `latr_vault_storage_errors_total` unchanged.

Mixin alerts/dashboard group by `team` as well so on-call can route by owning team.