### PR TITLE
fix: remove default CPU limit from resources

### DIFF
--- a/helm/latr/README.md
+++ b/helm/latr/README.md
@@ -122,7 +122,6 @@ The following table lists the configurable parameters of the latr chart and thei
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `256Mi` |
 | `resources.requests.cpu` | CPU request | `100m` |
 | `resources.requests.memory` | Memory request | `128Mi` |

--- a/helm/latr/values.yaml
+++ b/helm/latr/values.yaml
@@ -45,7 +45,6 @@ securityContext:
 
 resources:
   limits:
-    cpu: 500m
     memory: 256Mi
   requests:
     cpu: 100m


### PR DESCRIPTION
CPU limits cause throttling even when a container is nowhere near its CPU request; drop it and keep the memory limit for OOM protection. https://home.robusta.dev/blog/stop-using-cpu-limits